### PR TITLE
Network [#41] 일기 답장 조회 API 연결 준비

### DIFF
--- a/Clody_iOS/Clody_iOS/Network/Service/DTO/DiaryModel/GetReplyResponseDTO.swift
+++ b/Clody_iOS/Clody_iOS/Network/Service/DTO/DiaryModel/GetReplyResponseDTO.swift
@@ -8,5 +8,8 @@
 import Foundation
 
 struct GetReplyResponseDTO: Codable {
-    let Content: String
+    let content: String
+    let nickname: String
+    let month: Int
+    let date: Int
 }

--- a/Clody_iOS/Clody_iOS/Presentation/Calendar/ViewControllers/CalendarViewController.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Calendar/ViewControllers/CalendarViewController.swift
@@ -175,7 +175,7 @@ private extension CalendarViewController {
             .emit(onNext: { [weak self] in
                 guard let self = self else { return }
                 if viewModel.dailyDiaryDataRelay.value.diaries.count != 0 {
-                    self.navigationController?.pushViewController(ReplyWaitingViewController(), animated: true)
+//                    self.navigationController?.pushViewController(ReplyWaitingViewController(), animated: true)
                 } else {
                     self.navigationController?.pushViewController(WritingDiaryViewController(), animated: true)
                 }

--- a/Clody_iOS/Clody_iOS/Presentation/Reply/ViewControllers/ReplyDetailViewController.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Reply/ViewControllers/ReplyDetailViewController.swift
@@ -18,15 +18,35 @@ final class ReplyDetailViewController: UIViewController {
     
     private let viewModel = ReplyDetailViewModel()
     private let disposeBag = DisposeBag()
-    private let nickname = "밤빵식"
+    private let nickname: String
+    private let content: String
+    private let month: Int
+    private let date: Int
     
     // MARK: - UI Components
     
-    private let rootView = ReplyDetailView()
+    private lazy var rootView = ReplyDetailView(
+        month: month,
+        date: date,
+        nickname: nickname,
+        content: content
+    )
     private lazy var getClodyAlertView = GetCloverAlertView(nickname: nickname)
     private let dimmingView = UIView()
     
     // MARK: - Life Cycles
+    
+    init(data: GetReplyResponseDTO) {
+        self.nickname = data.nickname
+        self.content = data.content
+        self.month = data.month
+        self.date = data.date
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override func loadView() {
         super.loadView()

--- a/Clody_iOS/Clody_iOS/Presentation/Reply/ViewControllers/ReplyWaitingViewController.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Reply/ViewControllers/ReplyWaitingViewController.swift
@@ -17,7 +17,10 @@ final class ReplyWaitingViewController: UIViewController {
     
     private let viewModel = ReplyWaitingViewModel()
     private let disposeBag = DisposeBag()
-    private var totalSeconds = 5
+    private var totalSeconds = 60
+    private var year: Int
+    private var month: Int
+    private var date: Int
     
     // MARK: - UI Components
      
@@ -26,6 +29,17 @@ final class ReplyWaitingViewController: UIViewController {
     private lazy var openButton = rootView.openButton
     
     // MARK: - Life Cycles
+    
+    init(year: Int, month: Int, date: Int) {
+        self.year = year
+        self.month = month
+        self.date = date
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override func loadView() {
         super.loadView()
@@ -73,15 +87,26 @@ private extension ReplyWaitingViewController {
             })
             .disposed(by: disposeBag)
         
-        output.pushReplyDetailViewController
+        output.getReply
             .drive(onNext: { [weak self] in
-                let replyDetailViewController = ReplyDetailViewController()
-                self?.navigationController?.pushViewController(replyDetailViewController, animated: false)
+                self?.getReply()
             })
             .disposed(by: disposeBag)
     }
 
     func setUI() {
         self.navigationController?.isNavigationBarHidden = true
+    }
+}
+
+private extension ReplyWaitingViewController {
+    
+    func getReply() {
+        viewModel.getReply(year: year, month: month, date: date) { data in
+            self.navigationController?.pushViewController(
+                ReplyDetailViewController(data: data),
+                animated: false
+            )
+        }
     }
 }

--- a/Clody_iOS/Clody_iOS/Presentation/Reply/ViewModels/ReplyWaitingViewModel.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Reply/ViewModels/ReplyWaitingViewModel.swift
@@ -20,7 +20,7 @@ final class ReplyWaitingViewModel: ViewModelType {
     struct Output {
         let timeLabelDidChange: Driver<String>
         let replyArrivalEvent: Driver<Void>
-        let pushReplyDetailViewController: Driver<Void>
+        let getReply: Driver<Void>
     }
     
     func transform(from input: Input, disposeBag: DisposeBag) -> Output {
@@ -49,13 +49,28 @@ final class ReplyWaitingViewModel: ViewModelType {
             }
             .asDriver(onErrorJustReturn: Void())
         
-        let pushReplyDetailViewController = input.openButtonTapEvent
+        let getReply = input.openButtonTapEvent
             .asDriver(onErrorJustReturn: Void())
         
         return Output(
             timeLabelDidChange: timeLabelDidChange,
             replyArrivalEvent: replyArrivalEvent,
-            pushReplyDetailViewController: pushReplyDetailViewController
+            getReply: getReply
         )
+    }
+}
+
+extension ReplyWaitingViewModel {
+    
+    func getReply(year: Int, month: Int, date: Int, completion: @escaping (GetReplyResponseDTO) -> ()) {
+        Providers.diaryRouter.request(
+            target: .getReply(year: year, month: month, date: date),
+            instance: BaseResponse<GetReplyResponseDTO>.self
+        ) { response in
+            if let data = response.data {
+                print(data)
+                completion(data)
+            }
+        }
     }
 }

--- a/Clody_iOS/Clody_iOS/Presentation/Reply/Views/ReplyDetailView.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Reply/Views/ReplyDetailView.swift
@@ -12,13 +12,34 @@ import Then
 
 final class ReplyDetailView: BaseView {
     
-    private lazy var navigationBar = ClodyNavigationBar(type: .reply, title: dummyData.date)
+    private lazy var navigationBar = ClodyNavigationBar(type: .reply, title: "\(month)월 \(date)일")
     private let backgroundView = UIView()
     private let rodyImageView = UIImageView()
     private lazy var titleLabel = UILabel()
     private lazy var replyTextView = UITextView()
     
-    private let dummyData = ReplyDetailModel.dummyData()
+    private let month: Int
+    private let date: Int
+    private let nickname: String
+    private let content: String
+    
+    init(
+        month: Int,
+        date: Int,
+        nickname: String,
+        content: String
+    ) {
+        self.month = month
+        self.date = date
+        self.nickname = nickname
+        self.content = content
+        
+        super.init(frame: .zero)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override func setStyle() {
         backgroundColor = .white
@@ -34,16 +55,17 @@ final class ReplyDetailView: BaseView {
         }
         
         titleLabel.do {
-            let title = dummyData.nickname + I18N.Reply.luckyReplyForYou
+            let title = nickname + I18N.Reply.luckyReplyForYou
             $0.textColor = .grey01
             $0.attributedText = UIFont.pretendardString(text: title, style: .body2_semibold)
+            $0.numberOfLines = 0
         }
         
         replyTextView.do {
             $0.backgroundColor = .clear
             $0.textColor = .grey02
             $0.attributedText = UIFont.pretendardString(
-                text: dummyData.reply,
+                text: content,
                 style: .letter_medium,
                 lineHeightMultiple: 1.9
             )
@@ -78,6 +100,7 @@ final class ReplyDetailView: BaseView {
         
         titleLabel.snp.makeConstraints {
             $0.top.equalTo(rodyImageView.snp.bottom).offset(22)
+            $0.horizontalEdges.equalToSuperview().inset(24)
             $0.centerX.equalToSuperview()
         }
         


### PR DESCRIPTION
## 🍀 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 답장 대기 화면 -> 일기 답장 조회 API 연결 세팅

## 🚀 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- 일기 답장 조회 API 붙일 곳이 두 곳이라서...🥹  일단 답장 대기 화면에서 '열어보기' 버튼으로 연결되는 부분만 수정해놨습니다.
- 캘린더 화면에서 답장 확인 버튼으로 넘어가는 부분도 붙여야 합니다.
- 일기 작성 후 답장 대기 화면으로 넘어갈 때 year, month, date만 뷰컨트롤러 init() 파라미터로 전달해주면 됩니다.

- 저랑 선우랑 서로 할일 바꿔서 하기로 했습니다ㅋㅋ 그래서 피알 올림

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 화면종류 | 파일첨부바람 |

## ✚ 코드 리뷰 반영 사항
<!-- 반영한 코드 리뷰 내용이 있다면 적어주세요! -->

## ✅ CheckList
- [ ] 오류 없이 빌드되는지 확인
- [ ] 로그용 print문 제거
- [ ] 불필요한 주석 제거
- [ ] 코드 컨벤션 확인

### 🔗 Issue 
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #이슈번호
