### PR TITLE
Feat [#82] 기능, 디자인 QA 반영 업데이트

### DIFF
--- a/Clody_iOS/Clody_iOS.xcodeproj/project.pbxproj
+++ b/Clody_iOS/Clody_iOS.xcodeproj/project.pbxproj
@@ -16,7 +16,7 @@
 		0B20F3E62C2C4DAB00F8D62D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0B20F3E52C2C4DAB00F8D62D /* Assets.xcassets */; };
 		0B20F3E92C2C4DAB00F8D62D /* Base in Resources */ = {isa = PBXBuildFile; fileRef = 0B20F3E82C2C4DAB00F8D62D /* Base */; };
 		0B3DC0882C6CD77C0021AC61 /* ClodyErrorRetryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B3DC0872C6CD77C0021AC61 /* ClodyErrorRetryView.swift */; };
-		0B4A1BB92C44E59B00E31EC4 /* DatePickeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B4A1BB82C44E59B00E31EC4 /* DatePickeView.swift */; };
+		0B4A1BB92C44E59B00E31EC4 /* DatePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B4A1BB82C44E59B00E31EC4 /* DatePickerView.swift */; };
 		0B4A1BBC2C453F8400E31EC4 /* AuthIntercepter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B4A1BBB2C453F8400E31EC4 /* AuthIntercepter.swift */; };
 		0B4A1BBE2C453F9600E31EC4 /* NetworkProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B4A1BBD2C453F9600E31EC4 /* NetworkProvider.swift */; };
 		0B4A1BC02C453FB800E31EC4 /* BaseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B4A1BBF2C453FB800E31EC4 /* BaseModel.swift */; };
@@ -165,7 +165,7 @@
 		0B20F3E82C2C4DAB00F8D62D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		0B20F3EA2C2C4DAB00F8D62D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0B3DC0872C6CD77C0021AC61 /* ClodyErrorRetryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClodyErrorRetryView.swift; sourceTree = "<group>"; };
-		0B4A1BB82C44E59B00E31EC4 /* DatePickeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickeView.swift; sourceTree = "<group>"; };
+		0B4A1BB82C44E59B00E31EC4 /* DatePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatePickerView.swift; sourceTree = "<group>"; };
 		0B4A1BBB2C453F8400E31EC4 /* AuthIntercepter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthIntercepter.swift; sourceTree = "<group>"; };
 		0B4A1BBD2C453F9600E31EC4 /* NetworkProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProvider.swift; sourceTree = "<group>"; };
 		0B4A1BBF2C453FB800E31EC4 /* BaseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseModel.swift; sourceTree = "<group>"; };
@@ -708,7 +708,7 @@
 			children = (
 				0BFCC5E02C2E8F2800B5E0DB /* CalendarView.swift */,
 				0BAAC64D2C43BFD900174A9D /* DeleteBottomSheetView.swift */,
-				0B4A1BB82C44E59B00E31EC4 /* DatePickeView.swift */,
+				0B4A1BB82C44E59B00E31EC4 /* DatePickerView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1076,7 +1076,7 @@
 				0BE7EA0B2C46699F000C5358 /* GetAlarmResponseDTO.swift in Sources */,
 				95310FC62C45ACD000023C7B /* OnBoardingViewModel.swift in Sources */,
 				0BAAC64E2C43BFD900174A9D /* DeleteBottomSheetView.swift in Sources */,
-				0B4A1BB92C44E59B00E31EC4 /* DatePickeView.swift in Sources */,
+				0B4A1BB92C44E59B00E31EC4 /* DatePickerView.swift in Sources */,
 				0BAAC6552C43D77B00174A9D /* ClodyToastView.swift in Sources */,
 				0BE7E9FC2C4660AC000C5358 /* GetWritingTimeDTO.swift in Sources */,
 				95310F982C40777C00023C7B /* OnBoardingView.swift in Sources */,

--- a/Clody_iOS/Clody_iOS/Global/Literals/String.swift
+++ b/Clody_iOS/Clody_iOS/Global/Literals/String.swift
@@ -33,12 +33,12 @@ enum I18N {
         static let saveDiaryTitle = "일기를 저장할까요?"
         static let saveDiaryMessage = "저장한 일기는 수정이 어려워요."
         static let deleteDiaryTitle = "정말 일기를 삭제할까요?"
-        static let deleteDiaryMessage = "삭제한 일기는 복원이 어려워요."
+        static let deleteDiaryMessage = "아직 답장이 오지 않았거나 삭제하고\n다시 작성한 일기는 답장을 받을 수 없어요."
         static let cancel = "아니요"
         static let logout = "로그아웃"
         static let withdraw = "탈퇴할래요"
         static let save = "저장하기"
-        static let delete = "삭제하기"
+        static let delete = "삭제할래요"
         static let retry = "다시 시도"
     }
     

--- a/Clody_iOS/Clody_iOS/Global/Literals/String.swift
+++ b/Clody_iOS/Clody_iOS/Global/Literals/String.swift
@@ -33,7 +33,7 @@ enum I18N {
         static let saveDiaryTitle = "일기를 저장할까요?"
         static let saveDiaryMessage = "저장한 일기는 수정이 어려워요."
         static let deleteDiaryTitle = "정말 일기를 삭제할까요?"
-        static let deleteDiaryMessage = "아직 답장이 오지 않았거나 삭제하고\n다시 작성한 일기는 답장을 받을 수 없어요."
+        static let deleteDiaryMessage = "아직 답장이 오지 않았거나 삭제하고 다시 작성한 일기는 답장을 받을 수 없어요."
         static let cancel = "아니요"
         static let logout = "로그아웃"
         static let withdraw = "탈퇴할래요"

--- a/Clody_iOS/Clody_iOS/Presentation/Auth/ViewControllers/DiaryNotificationViewController.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Auth/ViewControllers/DiaryNotificationViewController.swift
@@ -87,7 +87,7 @@ private extension DiaryNotificationViewController {
             })
             .disposed(by: disposeBag)
         
-        timePickerView.closeButton.rx.tap
+        timePickerView.navigationBar.xButton.rx.tap
             .subscribe(onNext: { [weak self] _ in
                 self?.dismissPickerView(animated: true, completion: nil)
             })

--- a/Clody_iOS/Clody_iOS/Presentation/Auth/Views/NicknameView.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Auth/Views/NicknameView.swift
@@ -57,7 +57,6 @@ final class NicknameView: BaseView {
         }
         
         textField.snp.makeConstraints {
-            $0.height.equalTo(ScreenUtils.getHeight(51))
             $0.top.equalTo(introLabel.snp.bottom).offset(ScreenUtils.getHeight(40))
             $0.horizontalEdges.equalToSuperview().inset(ScreenUtils.getWidth(24))
         }

--- a/Clody_iOS/Clody_iOS/Presentation/Auth/Views/NotificationPickerView.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Auth/Views/NotificationPickerView.swift
@@ -20,14 +20,13 @@ final class NotificationPickerView: BaseView {
     
     let dimmedView = UIView()
     let backgroundView = UIView()
+    let navigationBar: ClodyNavigationBar
     let pickerView = ClodyPickerView(type: .notification)
-    let closeButton = UIButton()
-    private let titleLabel = UILabel()
     lazy var completeButton = UIButton()
-    private let layoutGuide = UILayoutGuide()
     
     init(title: String) {
         self.title = title
+        self.navigationBar = ClodyNavigationBar(type: .bottomSheet, title: title)
         super.init(frame: .zero)
     }
     
@@ -47,15 +46,6 @@ final class NotificationPickerView: BaseView {
             $0.clipsToBounds = true
         }
         
-        titleLabel.do {
-            $0.textColor = .grey01
-            $0.attributedText = UIFont.pretendardString(text: title, style: .body2_semibold)
-        }
-        
-        closeButton.do {
-            $0.setImage(.icX, for: .normal)
-        }
-        
         completeButton.do {
             $0.backgroundColor = .mainYellow
             $0.makeCornerRound(radius: 10)
@@ -66,56 +56,38 @@ final class NotificationPickerView: BaseView {
     }
     
     override func setHierarchy() {
-        self.addLayoutGuide(layoutGuide)
         self.addSubviews(dimmedView, backgroundView)
-        backgroundView.addSubviews(
-            pickerView,
-            titleLabel,
-            closeButton,
-            completeButton
-        )
+        backgroundView.addSubviews(navigationBar, pickerView, completeButton)
     }
     
     override func setLayout() {
-        layoutGuide.snp.makeConstraints {
-            $0.top.equalTo(closeButton.snp.bottom)
-            $0.horizontalEdges.equalToSuperview()
-            $0.bottom.equalTo(completeButton.snp.top)
-        }
-        
         dimmedView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
         
         backgroundView.snp.makeConstraints {
             $0.horizontalEdges.bottom.equalToSuperview()
-            $0.height.equalTo(ScreenUtils.getHeight(360))
+        }
+        
+        navigationBar.snp.makeConstraints {
+            $0.height.equalTo(ScreenUtils.getHeight(52))
+            $0.top.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview()
         }
         
         pickerView.snp.makeConstraints {
-            $0.horizontalEdges.equalTo(completeButton)
-            $0.center.equalTo(layoutGuide)
             $0.height.equalTo(ScreenUtils.getHeight(223))
-        }
-        
-        titleLabel.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.top.equalToSuperview().inset(ScreenUtils.getHeight(14))
-        }
-        
-        closeButton.snp.makeConstraints {
-            $0.centerY.equalTo(titleLabel)
-            $0.trailing.equalToSuperview().inset(ScreenUtils.getWidth(18))
-            $0.size.equalTo(ScreenUtils.getWidth(24))
+            $0.top.equalTo(navigationBar.snp.bottom).offset(ScreenUtils.getHeight(2))
+            $0.horizontalEdges.equalTo(completeButton)
+            $0.bottom.equalTo(completeButton.snp.top).offset(ScreenUtils.getHeight(-3))
         }
         
         completeButton.snp.makeConstraints {
+            $0.height.equalTo(ScreenUtils.getHeight(48))
             $0.horizontalEdges.equalToSuperview().inset(ScreenUtils.getWidth(24))
             $0.bottom.equalTo(safeAreaLayoutGuide).inset(ScreenUtils.getHeight(5))
-            $0.height.equalTo(ScreenUtils.getHeight(48))
         }
     }
-
     
     func animateShow() {
         self.backgroundView.transform = CGAffineTransform(translationX: 0, y: self.backgroundView.frame.height)

--- a/Clody_iOS/Clody_iOS/Presentation/Calendar/ViewControllers/CalendarViewController.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Calendar/ViewControllers/CalendarViewController.swift
@@ -31,7 +31,7 @@ final class CalendarViewController: UIViewController {
     
     private let rootView = CalendarView()
     private let deleteBottomSheetView = DeleteBottomSheetView()
-    private let datePickerView = DatePickeView()
+    private let datePickerView = DatePickerView()
     
     // MARK: - Life Cycles
     
@@ -330,7 +330,7 @@ private extension CalendarViewController {
         
         datePickerView.isHidden = true
         
-        datePickerView.cancelIcon.rx.tap
+        datePickerView.navigationBar.xButton.rx.tap
             .subscribe(onNext: {
                 self.dismissPickerView(animated: true, completion: {
                     

--- a/Clody_iOS/Clody_iOS/Presentation/Calendar/Views/DatePickerView.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Calendar/Views/DatePickerView.swift
@@ -1,5 +1,5 @@
 //
-//  DatePickeView.swift
+//  DatePickerView.swift
 //  Clody_iOS
 //
 //  Created by Seonwoo Kim on 7/15/24.
@@ -10,15 +10,14 @@ import UIKit
 import SnapKit
 import Then
 
-final class DatePickeView: BaseView {
+final class DatePickerView: BaseView {
     
     // MARK: - UI Components
     
     let dimmedView = UIView()
     let backgroundView = UIView()
+    let navigationBar = ClodyNavigationBar(type: .bottomSheet, title: I18N.Calendar.otherDay)
     let pickerView = ClodyPickerView(type: .calendar)
-    let cancelIcon = UIButton()
-    private let titleLabel = UILabel()
     lazy var completeButton = UIButton()
     
     override func setStyle() {
@@ -33,15 +32,6 @@ final class DatePickeView: BaseView {
             $0.clipsToBounds = true
         }
         
-        titleLabel.do {
-            $0.textColor = .grey01
-            $0.attributedText = UIFont.pretendardString(text: I18N.Calendar.otherDay, style: .body2_semibold)
-        }
-        
-        cancelIcon.do {
-            $0.setImage(.icX, for: .normal)
-        }
-        
         completeButton.do {
             $0.backgroundColor = .mainYellow
             $0.makeCornerRound(radius: 10)
@@ -53,12 +43,7 @@ final class DatePickeView: BaseView {
     
     override func setHierarchy() {
         self.addSubviews(dimmedView, backgroundView)
-        backgroundView.addSubviews(
-            pickerView,
-            titleLabel,
-            cancelIcon,
-            completeButton
-        )
+        backgroundView.addSubviews(pickerView, navigationBar, completeButton)
     }
     
     override func setLayout() {
@@ -68,30 +53,25 @@ final class DatePickeView: BaseView {
         
         backgroundView.snp.makeConstraints {
             $0.horizontalEdges.bottom.equalToSuperview()
-            $0.height.equalTo(ScreenUtils.getHeight(360))
+        }
+        
+        navigationBar.snp.makeConstraints {
+            $0.height.equalTo(ScreenUtils.getHeight(52))
+            $0.top.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview()
         }
         
         pickerView.snp.makeConstraints {
-            $0.horizontalEdges.equalTo(completeButton)
-            $0.bottom.equalTo(completeButton.snp.top).offset(ScreenUtils.getHeight(8))
             $0.height.equalTo(ScreenUtils.getHeight(223))
-        }
-        
-        titleLabel.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.top.equalToSuperview().inset(ScreenUtils.getHeight(14))
-        }
-        
-        cancelIcon.snp.makeConstraints {
-            $0.centerY.equalTo(titleLabel)
-            $0.trailing.equalToSuperview().inset(ScreenUtils.getWidth(18))
-            $0.size.equalTo(ScreenUtils.getWidth(24))
+            $0.top.equalTo(navigationBar.snp.bottom).offset(ScreenUtils.getHeight(-7))
+            $0.horizontalEdges.equalTo(completeButton)
+            $0.bottom.equalTo(completeButton.snp.top).offset(ScreenUtils.getHeight(-8))
         }
         
         completeButton.snp.makeConstraints {
+            $0.height.equalTo(ScreenUtils.getHeight(48))
             $0.horizontalEdges.equalToSuperview().inset(ScreenUtils.getWidth(24))
             $0.bottom.equalTo(safeAreaLayoutGuide).inset(ScreenUtils.getHeight(5))
-            $0.height.equalTo(ScreenUtils.getHeight(48))
         }
     }
 
@@ -112,4 +92,3 @@ final class DatePickeView: BaseView {
         })
     }
 }
-

--- a/Clody_iOS/Clody_iOS/Presentation/Common/Component/ClodyNavigationBar.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Common/Component/ClodyNavigationBar.swift
@@ -116,7 +116,10 @@ final class ClodyNavigationBar: UIView {
     
     var titleText: String = "" {
         didSet {
-            titleLabel.attributedText = UIFont.pretendardString(text: titleText, style: .head4)
+            titleLabel.attributedText = UIFont.pretendardString(
+                text: titleText,
+                style: (type == .bottomSheet) ? .body2_semibold : .head4
+            )
         }
     }
     
@@ -180,7 +183,7 @@ private extension ClodyNavigationBar {
         self.backgroundColor = .white
         
         if type == .bottomSheet {
-            titleLabel.attributedText = UIFont.pretendardString(text: titleText, style: .body1_semibold)
+            titleLabel.attributedText = UIFont.pretendardString(text: titleText, style: .body2_semibold)
         }
     }
 }

--- a/Clody_iOS/Clody_iOS/Presentation/Common/Component/ClodyTextField.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Common/Component/ClodyTextField.swift
@@ -56,7 +56,7 @@ final class ClodyTextField: BaseView {
         }
         
         underline.do {
-            $0.backgroundColor = .grey07
+            $0.backgroundColor = .grey08
         }
         
         messageLabel.do {
@@ -98,6 +98,7 @@ final class ClodyTextField: BaseView {
             $0.top.equalTo(underline.snp.bottom).offset(ScreenUtils.getHeight(3))
             $0.leading.equalToSuperview()
             $0.trailing.equalTo(countLabel.snp.leading).offset(-ScreenUtils.getWidth(16))
+            $0.bottom.equalToSuperview()
         }
         
         countLabel.snp.makeConstraints {
@@ -135,7 +136,7 @@ extension ClodyTextField {
     
     func setFocusState(to isFocused: Bool) {
         if underline.backgroundColor != UIColor.redCustom {
-            underline.backgroundColor = isFocused ? .mainYellow : .grey07
+            underline.backgroundColor = isFocused ? .mainYellow : .grey08
         }
     }
 }

--- a/Clody_iOS/Clody_iOS/Presentation/List/ViewControllers/ListViewController.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/List/ViewControllers/ListViewController.swift
@@ -26,7 +26,7 @@ final class ListViewController: UIViewController {
     // MARK: - UI Components
     
     private let rootView = ListView()
-    private let datePickerView = DatePickeView()
+    private let datePickerView = DatePickerView()
     private let deleteBottomSheetView = DeleteBottomSheetView()
     private var alert: ClodyAlert?
     private lazy var dimmingView = UIView()
@@ -248,7 +248,7 @@ private extension ListViewController {
         }
         datePickerView.isHidden = true
         
-        datePickerView.cancelIcon.rx.tap
+        datePickerView.navigationBar.xButton.rx.tap
             .subscribe(onNext: {
                 self.dismissPickerView(animated: true, completion: {
                     

--- a/Clody_iOS/Clody_iOS/Presentation/MyPage/ViewControllers/AccountViewController.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/MyPage/ViewControllers/AccountViewController.swift
@@ -339,7 +339,6 @@ private extension AccountViewController {
         }
         
         changeNicknameBottomSheet.snp.makeConstraints {
-            $0.height.equalTo(ScreenUtils.getHeight(272))
             $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalToSuperview()
         }

--- a/Clody_iOS/Clody_iOS/Presentation/MyPage/ViewControllers/NotificationViewController.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/MyPage/ViewControllers/NotificationViewController.swift
@@ -94,7 +94,7 @@ private extension NotificationViewController {
             })
             .disposed(by: disposeBag)
         
-        timePickerView.closeButton.rx.tap
+        timePickerView.navigationBar.xButton.rx.tap
             .subscribe(onNext: { [weak self] _ in
                 self?.dismissPickerView(animated: true, completion: nil)
             })

--- a/Clody_iOS/Clody_iOS/Presentation/MyPage/Views/AccountView.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/MyPage/Views/AccountView.swift
@@ -52,7 +52,7 @@ final class AccountView: BaseView {
         }
         
         changeProfileButton.do {
-            let attributedTitle = UIFont.pretendardString(text: "변경하기", style: .body4_medium)
+            let attributedTitle = UIFont.pretendardString(text: I18N.MyPage.edit, style: .body4_medium)
             $0.setAttributedTitle(attributedTitle, for: .normal)
             $0.setTitleColor(.grey05, for: .normal)
         }

--- a/Clody_iOS/Clody_iOS/Presentation/MyPage/Views/ChangeNicknameBottomSheet.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/MyPage/Views/ChangeNicknameBottomSheet.swift
@@ -24,7 +24,6 @@ final class ChangeNicknameBottomSheet: BaseView {
         backgroundColor = .white
         makeCornerRound(radius: 16)
         layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-        // TODO: placeholder 설정
     }
     
     override func setHierarchy() {
@@ -39,15 +38,15 @@ final class ChangeNicknameBottomSheet: BaseView {
         }
 
         clodyTextField.snp.makeConstraints {
-            $0.height.equalTo(ScreenUtils.getHeight(51))
             $0.top.equalTo(navigationBar.snp.bottom).offset(ScreenUtils.getHeight(32))
             $0.horizontalEdges.equalToSuperview().inset(ScreenUtils.getWidth(24))
+            $0.bottom.equalTo(doneButton.snp.top).offset(ScreenUtils.getHeight(-55))
         }
 
         doneButton.snp.makeConstraints {
             $0.height.equalTo(ScreenUtils.getHeight(48))
             $0.horizontalEdges.equalToSuperview().inset(ScreenUtils.getWidth(24))
-            $0.bottom.equalTo(safeAreaLayoutGuide).inset(ScreenUtils.getHeight(26))
+            $0.bottom.equalTo(safeAreaLayoutGuide).inset(ScreenUtils.getHeight(5))
         }
     }
 }

--- a/Clody_iOS/Clody_iOS/Presentation/Reply/ViewControllers/ReplyWaitingViewController.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Reply/ViewControllers/ReplyWaitingViewController.swift
@@ -51,20 +51,31 @@ final class ReplyWaitingViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        addObserverForAppDidBecomeActive()
         bindViewModel()
         setUI()
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 }
 
 // MARK: - Extensions
 
 private extension ReplyWaitingViewController {
+    
+    func addObserverForAppDidBecomeActive() {
+        /// 앱이 백그라운드에서 돌아와 다시 Active 상태가 될 때를 관찰하는 Observer
+        NotificationCenter.default.addObserver(self, selector: #selector(appDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
+    }
+    
+    @objc
+    private func appDidBecomeActive() {
+        Observable.just(())
+            .bind(to: viewModel.appDidBecomeActive)
+            .disposed(by: disposeBag)
+    }
 
     func bindViewModel() {
         

--- a/Clody_iOS/Clody_iOS/Presentation/Reply/ViewModels/ReplyWaitingViewModel.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Reply/ViewModels/ReplyWaitingViewModel.swift
@@ -27,10 +27,15 @@ final class ReplyWaitingViewModel: ViewModelType {
         let popViewController: Driver<Void>
     }
     
+    let appDidBecomeActive = PublishRelay<Void>()
     let errorStatus = PublishRelay<NetworkViewJudge>()
     
     func transform(from input: Input, disposeBag: DisposeBag) -> Output {
-        let getWritingTime = input.viewDidLoad
+        let getWritingTime = Observable
+            .merge(
+                input.viewDidLoad.asObservable(),
+                appDidBecomeActive.asObservable()
+            )
             .asDriver(onErrorJustReturn: ())
         
         let timeLabelDidChange = input.timer

--- a/Clody_iOS/Clody_iOS/Presentation/Reply/ViewModels/ReplyWaitingViewModel.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Reply/ViewModels/ReplyWaitingViewModel.swift
@@ -16,6 +16,7 @@ final class ReplyWaitingViewModel: ViewModelType {
         let viewDidLoad: Signal<Void>
         let timer: Observable<Int>
         let openButtonTapEvent: Signal<Void>
+        let backButtonTapEvent: Signal<Void>
     }
         
     struct Output {
@@ -23,6 +24,7 @@ final class ReplyWaitingViewModel: ViewModelType {
         let timeLabelDidChange: Driver<String>
         let replyArrivalEvent: Driver<Void>
         let pushViewController: Driver<Void>
+        let popViewController: Driver<Void>
     }
     
     let errorStatus = PublishRelay<NetworkViewJudge>()
@@ -59,11 +61,15 @@ final class ReplyWaitingViewModel: ViewModelType {
         let pushViewController = input.openButtonTapEvent
             .asDriver(onErrorJustReturn: ())
         
+        let popViewController = input.backButtonTapEvent
+            .asDriver(onErrorJustReturn: ())
+        
         return Output(
             getWritingTime: getWritingTime,
             timeLabelDidChange: timeLabelDidChange,
             replyArrivalEvent: replyArrivalEvent,
-            pushViewController: pushViewController
+            pushViewController: pushViewController, 
+            popViewController: popViewController
         )
     }
 }


### PR DESCRIPTION
## 🍀 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 닉네임, 알림 설정, 날짜 변경 바텀시트 UI 개선 및 레이아웃 수정
- 앱이 백그라운드 상태에서 다시 돌아왔을 때 타이머 시간 재설정
#### 설정 코드 리팩토링도 곧 하겠습니닷 🤡

## 🚀 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
### 앱 자체의 생명주기를 생각해야 한다!
❌ 앱 상태 관련해서는 뷰컨트롤러의 viewWillAppear (뷰의 생명주기)에서 구현이 안 된다는 사실...
백그라운드에서 다시 포그라운드로 돌아와도 viewWillAppear()이 호출되지 않음!! 😓

✅ 그래서 NotificationCenter를 사용해 앱이 Active 상태가 될 때를 관찰한다~
아래는 포그라운드로 돌아올 때 appDidBecomeActive() 함수가 실행되어 뷰모델 relay로 이벤트를 방출하는 코드입니다.
그럼 그 relay를 구독하는 애가 일기 작성 시간을 조회합니다~
```
private extension ReplyWaitingViewController {

    func addObserverForAppDidBecomeActive() {
        /// 앱이 백그라운드에서 돌아와 다시 Active 상태가 될 때를 관찰하는 Observer
        NotificationCenter.default.addObserver(self, selector: #selector(appDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
    }

    @objc
    private func appDidBecomeActive() {
        Observable.just(())
            .bind(to: viewModel.appDidBecomeActive)
            .disposed(by: disposeBag)
    }
```

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 바텀시트 | <img src="https://github.com/user-attachments/assets/50475655-2fdd-46d3-ab7d-4afd4027e7e4" width = 250> |

## ✚ 코드 리뷰 반영 사항
<!-- 반영한 코드 리뷰 내용이 있다면 적어주세요! -->

## ✅ CheckList
- [x] 오류 없이 빌드되는지 확인
- [x] 로그용 print문 제거
- [x] 불필요한 주석 제거
- [x] 코드 컨벤션 확인

### 🔗 Issue 
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #82
