### PR TITLE
Fix [#93] 캘린더 전날 일기 작성 가능으로 수정

### DIFF
--- a/Clody_iOS/Clody_iOS.xcodeproj/project.pbxproj
+++ b/Clody_iOS/Clody_iOS.xcodeproj/project.pbxproj
@@ -1358,7 +1358,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Clody.Clody;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1394,7 +1394,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Clody.Clody;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Clody_iOS/Clody_iOS/Global/Extensions/Date+.swift
+++ b/Clody_iOS/Clody_iOS/Global/Extensions/Date+.swift
@@ -41,7 +41,7 @@ extension Date {
         return Calendar.current.isDate(self, equalTo: Date().addingTimeInterval(-86400), toGranularity: .day)
     }
 
-    var isAvailable: Bool {
+    var isWritingAvailable: Bool {
         return isToday || isYesterday
     }
 }

--- a/Clody_iOS/Clody_iOS/Global/Extensions/Date+.swift
+++ b/Clody_iOS/Clody_iOS/Global/Extensions/Date+.swift
@@ -32,4 +32,16 @@ extension Date {
         let totalSeconds = today.timeIntervalSince(midnight)
         return Int(totalSeconds)
     }
+    
+    var isToday: Bool {
+        return Calendar.current.isDateInToday(self)
+    }
+
+    var isYesterday: Bool {
+        return Calendar.current.isDate(self, equalTo: Date().addingTimeInterval(-86400), toGranularity: .day)
+    }
+
+    var isAvailable: Bool {
+        return isToday || isYesterday
+    }
 }

--- a/Clody_iOS/Clody_iOS/Presentation/Calendar/Cells/CalendarDateCell.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Calendar/Cells/CalendarDateCell.swift
@@ -99,7 +99,7 @@ final class CalendarDateCell: FSCalendarCell {
 
 extension CalendarDateCell {
     
-    func configure(isAvailable: Bool, isSelected: Bool, isDeleted: Bool, date: String, data: MonthlyDiary) {
+    func configure(isWrtingAvailable: Bool, isSelected: Bool, isDeleted: Bool, date: String, data: MonthlyDiary) {
         // 캘린더 분기처리 로직
         cloverImageView.image = UIImage(named: "clover\(data.diaryCount)")
         backgroundSelectView.isHidden = true
@@ -120,8 +120,8 @@ extension CalendarDateCell {
             cloverImageView.image = .clover0
         }
         
-        // 오늘 날짜 처리
-        if isAvailable {
+        // 작성 가능 날짜 처리
+        if isWrtingAvailable {
             if data.diaryCount == 0 {
                 cloverImageView.image = .cloverToday
             } else {
@@ -138,7 +138,7 @@ extension CalendarDateCell {
             backgroundSelectView.isHidden = false
             calendarDateLabel.attributedText = UIFont.pretendardString(text: date, style: .detail1_medium, color: .white)
         } else {
-            calendarDateLabel.attributedText = UIFont.pretendardString(text: date, style: .detail1_medium, color: isAvailable ? .black : .grey05)
+            calendarDateLabel.attributedText = UIFont.pretendardString(text: date, style: .detail1_medium, color: isWrtingAvailable ? .black : .grey05)
         }
     }
 }

--- a/Clody_iOS/Clody_iOS/Presentation/Calendar/Cells/CalendarDateCell.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Calendar/Cells/CalendarDateCell.swift
@@ -99,7 +99,7 @@ final class CalendarDateCell: FSCalendarCell {
 
 extension CalendarDateCell {
     
-    func configure(isToday: Bool, isSelected: Bool, isDeleted: Bool, date: String, data: MonthlyDiary) {
+    func configure(isAvailable: Bool, isSelected: Bool, isDeleted: Bool, date: String, data: MonthlyDiary) {
         // 캘린더 분기처리 로직
         cloverImageView.image = UIImage(named: "clover\(data.diaryCount)")
         backgroundSelectView.isHidden = true
@@ -121,7 +121,7 @@ extension CalendarDateCell {
         }
         
         // 오늘 날짜 처리
-        if isToday {
+        if isAvailable {
             if data.diaryCount == 0 {
                 cloverImageView.image = .cloverToday
             } else {
@@ -138,7 +138,7 @@ extension CalendarDateCell {
             backgroundSelectView.isHidden = false
             calendarDateLabel.attributedText = UIFont.pretendardString(text: date, style: .detail1_medium, color: .white)
         } else {
-            calendarDateLabel.attributedText = UIFont.pretendardString(text: date, style: .detail1_medium, color: isToday ? .black : .grey05)
+            calendarDateLabel.attributedText = UIFont.pretendardString(text: date, style: .detail1_medium, color: isAvailable ? .black : .grey05)
         }
     }
 }

--- a/Clody_iOS/Clody_iOS/Presentation/Calendar/ViewControllers/CalendarViewController.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Calendar/ViewControllers/CalendarViewController.swift
@@ -90,7 +90,7 @@ private extension CalendarViewController {
                 
                 let isNotEmpty = !data.isEmpty
                 let selectedDate = self.viewModel.selectedDateRelay.value
-                let isAvailable = selectedDate.isAvailable
+                let isWritingAvailable = selectedDate.isWritingAvailable
                 let isDeleted = self.viewModel.dailyDiaryDataRelay.value.isDeleted
                 
                 // 기본값 설정
@@ -100,7 +100,7 @@ private extension CalendarViewController {
                 var isEnabled = true
                 
                 // 버튼 상태 및 색상 결정
-                if (isAvailable && isNotEmpty && isDeleted) || (!isAvailable && (isDeleted || !isNotEmpty)) {
+                if (isWritingAvailable && isNotEmpty && isDeleted) || (!isWritingAvailable && (isDeleted || !isNotEmpty)) {
                     isEnabled = false
                     buttonColor = isNotEmpty ? UIColor(named: "grey07") : UIColor(named: "lightYellow")
                     textColor = UIColor(named: isNotEmpty ? "grey04" : "grey06")
@@ -436,14 +436,14 @@ extension CalendarViewController: FSCalendarDelegate, FSCalendarDataSource, FSCa
         let day = Calendar.current.component(.day, from: date) - 1
         let data: MonthlyDiary? = day >= 0 && day < calendarData.count ? calendarData[day] : nil
         
-        let isAvailable = date.isAvailable
+        let isWritingAvailable = date.isWritingAvailable
         let isSelected = Calendar.current.isDate(date, inSameDayAs: self.viewModel.selectedDateRelay.value)
         let isDeleted = data?.isDeleted ?? false
         let date = DateFormatter.string(from: date, format: "d")
         
         let dayString = String(day + 1)
         
-        cell.configure(isAvailable: isAvailable, isSelected: isSelected, isDeleted: isDeleted, date: date, data: data ?? MonthlyDiary(diaryCount: 0, replyStatus: "", isDeleted: false))
+        cell.configure(isWrtingAvailable: isWritingAvailable, isSelected: isSelected, isDeleted: isDeleted, date: date, data: data ?? MonthlyDiary(diaryCount: 0, replyStatus: "", isDeleted: false))
         return cell
     }
     

--- a/Clody_iOS/Clody_iOS/Presentation/Calendar/ViewControllers/CalendarViewController.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Calendar/ViewControllers/CalendarViewController.swift
@@ -91,6 +91,10 @@ private extension CalendarViewController {
                 let isNotEmpty = !data.isEmpty
                 let isToday = Calendar.current.isDateInToday(self.viewModel.selectedDateRelay.value)
                 let isDeleted = self.viewModel.dailyDiaryDataRelay.value.isDeleted
+                let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+                let isYesterday = Calendar.current.isDate(self.viewModel.selectedDateRelay.value, equalTo: yesterday, toGranularity: .day)
+                
+                let isAvailable = isToday || isYesterday
                 
                 // 기본값 설정
                 var buttonTitle = isNotEmpty ? I18N.Calendar.reply : I18N.Calendar.writing
@@ -99,7 +103,7 @@ private extension CalendarViewController {
                 var isEnabled = true
                 
                 // 버튼 상태 및 색상 결정
-                if (isToday && isNotEmpty && isDeleted) || (!isToday && (isDeleted || !isNotEmpty)) {
+                if (isAvailable && isNotEmpty && isDeleted) || (!isAvailable && (isDeleted || !isNotEmpty)) {
                     isEnabled = false
                     buttonColor = isNotEmpty ? UIColor(named: "grey07") : UIColor(named: "lightYellow")
                     textColor = UIColor(named: isNotEmpty ? "grey04" : "grey06")
@@ -436,13 +440,18 @@ extension CalendarViewController: FSCalendarDelegate, FSCalendarDataSource, FSCa
         let data: MonthlyDiary? = day >= 0 && day < calendarData.count ? calendarData[day] : nil
         
         let isToday = Calendar.current.isDateInToday(date)
+        
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
+        let isYesterday = Calendar.current.isDate(date, equalTo: yesterday, toGranularity: .day)
+        let isAvailable = isToday || isYesterday
+        
         let isSelected = Calendar.current.isDate(date, inSameDayAs: self.viewModel.selectedDateRelay.value)
         let isDeleted = data?.isDeleted ?? false
         let date = DateFormatter.string(from: date, format: "d")
         
         let dayString = String(day + 1)
         
-        cell.configure(isToday: isToday, isSelected: isSelected, isDeleted: isDeleted, date: date, data: data ?? MonthlyDiary(diaryCount: 0, replyStatus: "", isDeleted: false))
+        cell.configure(isToday: isAvailable, isSelected: isSelected, isDeleted: isDeleted, date: date, data: data ?? MonthlyDiary(diaryCount: 0, replyStatus: "", isDeleted: false))
         return cell
     }
     

--- a/Clody_iOS/Clody_iOS/Presentation/Calendar/ViewControllers/CalendarViewController.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Calendar/ViewControllers/CalendarViewController.swift
@@ -89,12 +89,9 @@ private extension CalendarViewController {
                 guard let self = self else { return }
                 
                 let isNotEmpty = !data.isEmpty
-                let isToday = Calendar.current.isDateInToday(self.viewModel.selectedDateRelay.value)
+                let selectedDate = self.viewModel.selectedDateRelay.value
+                let isAvailable = selectedDate.isAvailable
                 let isDeleted = self.viewModel.dailyDiaryDataRelay.value.isDeleted
-                let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
-                let isYesterday = Calendar.current.isDate(self.viewModel.selectedDateRelay.value, equalTo: yesterday, toGranularity: .day)
-                
-                let isAvailable = isToday || isYesterday
                 
                 // 기본값 설정
                 var buttonTitle = isNotEmpty ? I18N.Calendar.reply : I18N.Calendar.writing
@@ -439,19 +436,14 @@ extension CalendarViewController: FSCalendarDelegate, FSCalendarDataSource, FSCa
         let day = Calendar.current.component(.day, from: date) - 1
         let data: MonthlyDiary? = day >= 0 && day < calendarData.count ? calendarData[day] : nil
         
-        let isToday = Calendar.current.isDateInToday(date)
-        
-        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())!
-        let isYesterday = Calendar.current.isDate(date, equalTo: yesterday, toGranularity: .day)
-        let isAvailable = isToday || isYesterday
-        
+        let isAvailable = date.isAvailable
         let isSelected = Calendar.current.isDate(date, inSameDayAs: self.viewModel.selectedDateRelay.value)
         let isDeleted = data?.isDeleted ?? false
         let date = DateFormatter.string(from: date, format: "d")
         
         let dayString = String(day + 1)
         
-        cell.configure(isToday: isAvailable, isSelected: isSelected, isDeleted: isDeleted, date: date, data: data ?? MonthlyDiary(diaryCount: 0, replyStatus: "", isDeleted: false))
+        cell.configure(isAvailable: isAvailable, isSelected: isSelected, isDeleted: isDeleted, date: date, data: data ?? MonthlyDiary(diaryCount: 0, replyStatus: "", isDeleted: false))
         return cell
     }
     


### PR DESCRIPTION
## 🍀 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
# 어제 날짜를 클라이언트에서 계산
서버 측과 논의한 결과 그냥 클라이언트가 계산해서 넣는 걸로 했습니다!
따라서 기존 캘린더에 있던 isToday 부분에 or 연산 느낌으로 isYesterday도 넣어서 계산하는 로직으로 변경,,,
따라서 코드 몇줄로 쉽게 변경할 수 있었어요

# Date 익스텐션으로 분리
일기 작성 부분에도 전날을 판별하는 부분이 필요할 것 같아서, 좀 더 글로벌하게 이용되어도 좋겠다고 생각했어요.

따라서 Date+로 빼가지고 사용할 수 있습니다.

## 🚀 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- 전날을 판별하는 것에는 Date+의 해당 부분을 사용해 주세요

```swift
    var isToday: Bool {
        return Calendar.current.isDateInToday(self)
    }

    var isYesterday: Bool {
        return Calendar.current.isDate(self, equalTo: Date().addingTimeInterval(-86400), toGranularity: .day)
    }

    var isWritingAvailable: Bool {
        return isToday || isYesterday
    }

```

## ✚ 코드 리뷰 반영 사항
<!-- 반영한 코드 리뷰 내용이 있다면 적어주세요! -->

## ✅ CheckList
- [ ] 오류 없이 빌드되는지 확인
- [ ] 로그용 print문 제거
- [ ] 불필요한 주석 제거
- [ ] 코드 컨벤션 확인

### 🔗 Issue 
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #93 
