### PR TITLE
Feat [#114] In-App Review 인앱리뷰 요청 기능 구현

### DIFF
--- a/Clody_iOS/Clody_iOS.xcodeproj/project.pbxproj
+++ b/Clody_iOS/Clody_iOS.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 		95310FC22C45453F00023C7B /* NicknameViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95310FC12C45453F00023C7B /* NicknameViewModel.swift */; };
 		95310FC42C45A31700023C7B /* DiaryNotificationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95310FC32C45A31700023C7B /* DiaryNotificationViewModel.swift */; };
 		95310FC62C45ACD000023C7B /* OnBoardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95310FC52C45ACD000023C7B /* OnBoardingViewModel.swift */; };
+		953A393A2DF2AE2E00198C9D /* AppStoreReviewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953A39392DF2AE2E00198C9D /* AppStoreReviewManager.swift */; };
 		9556E2FD2DEB69120029FB95 /* NotificationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9556E2FC2DEB69120029FB95 /* NotificationState.swift */; };
 		9586C5612D8524DC00E12570 /* PostPatchAdRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9586C5602D8524DC00E12570 /* PostPatchAdRequestDTO.swift */; };
 		95A89E772C36EE4100E07ABC /* BaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95A89E762C36EE4100E07ABC /* BaseView.swift */; };
@@ -293,6 +294,7 @@
 		95310FC12C45453F00023C7B /* NicknameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameViewModel.swift; sourceTree = "<group>"; };
 		95310FC32C45A31700023C7B /* DiaryNotificationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryNotificationViewModel.swift; sourceTree = "<group>"; };
 		95310FC52C45ACD000023C7B /* OnBoardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnBoardingViewModel.swift; sourceTree = "<group>"; };
+		953A39392DF2AE2E00198C9D /* AppStoreReviewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreReviewManager.swift; sourceTree = "<group>"; };
 		9556E2FC2DEB69120029FB95 /* NotificationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationState.swift; sourceTree = "<group>"; };
 		9586C5602D8524DC00E12570 /* PostPatchAdRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostPatchAdRequestDTO.swift; sourceTree = "<group>"; };
 		95A89E762C36EE4100E07ABC /* BaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseView.swift; sourceTree = "<group>"; };
@@ -551,6 +553,7 @@
 				0BE7E9E92C45B0B8000C5358 /* UserManager.swift */,
 				0B4EF9D02C48C39600CAF1F6 /* PermissionManager.swift */,
 				0BABF7BD2C722313005A5CA1 /* AppVersionManager.swift */,
+				953A39392DF2AE2E00198C9D /* AppStoreReviewManager.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -1175,6 +1178,7 @@
 				0BA4DA132DEE8FB000D10568 /* CalendarCellData.swift in Sources */,
 				0B4A1BDA2C45636300E31EC4 /* SignUpRequestDTO.swift in Sources */,
 				95310F9C2C407F3C00023C7B /* OnBoardingDetailView.swift in Sources */,
+				953A393A2DF2AE2E00198C9D /* AppStoreReviewManager.swift in Sources */,
 				9556E2FD2DEB69120029FB95 /* NotificationState.swift in Sources */,
 				0BE7E9F92C4659F9000C5358 /* DiaryRouter.swift in Sources */,
 				0BE7EA0D2C466AB2000C5358 /* PostAlarmSetRequestDTO.swift in Sources */,

--- a/Clody_iOS/Clody_iOS/Global/Manager/AppStoreReviewManager.swift
+++ b/Clody_iOS/Clody_iOS/Global/Manager/AppStoreReviewManager.swift
@@ -1,0 +1,18 @@
+//
+//  AppStoreReviewManager.swift
+//  Clody_iOS
+//
+//  Created by 김나연 on 6/6/25.
+//
+
+import StoreKit
+
+enum AppStoreReviewManager {
+    
+    static func requestReview() {
+        guard let scene = UIApplication.shared.connectedScenes
+            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
+        else { return }
+        SKStoreReviewController.requestReview(in: scene)
+    }
+}

--- a/Clody_iOS/Clody_iOS/Global/Manager/AppStoreReviewManager.swift
+++ b/Clody_iOS/Clody_iOS/Global/Manager/AppStoreReviewManager.swift
@@ -8,11 +8,34 @@
 import StoreKit
 
 enum AppStoreReviewManager {
+    private static let hasRequestedReview_Key = "hasRequestedReview"
+    private static let hasViewedReply_Key = "hasViewedReply"
     
-    static func requestReview() {
-        guard let scene = UIApplication.shared.connectedScenes
-            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
-        else { return }
-        SKStoreReviewController.requestReview(in: scene)
+    static func requestReviewIfNeeded() {
+        guard !hasRequestedReview && hasViewedReply else { return }
+        
+        if let windowScene = UIApplication.shared.connectedScenes
+            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
+            SKStoreReviewController.requestReview(in: windowScene)
+        }
+        
+        hasRequestedReview = true
+    }
+    
+    static func markReplyAsViewed() {
+        hasViewedReply = true
+    }
+}
+
+extension AppStoreReviewManager {
+    
+    private static var hasRequestedReview: Bool {
+        get { UserDefaults.standard.bool(forKey: hasRequestedReview_Key) }
+        set { UserDefaults.standard.set(newValue, forKey: hasRequestedReview_Key) }
+    }
+    
+    private static var hasViewedReply: Bool {
+        get { UserDefaults.standard.bool(forKey: hasViewedReply_Key) }
+        set { UserDefaults.standard.set(newValue, forKey: hasViewedReply_Key) }
     }
 }

--- a/Clody_iOS/Clody_iOS/Presentation/Calendar/ViewControllers/CalendarViewController.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Calendar/ViewControllers/CalendarViewController.swift
@@ -48,6 +48,7 @@ final class CalendarViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
+        AppStoreReviewManager.requestReviewIfNeeded()
         viewModel.fetchData()
     }
     

--- a/Clody_iOS/Clody_iOS/Presentation/Reply/ViewControllers/ReplyDetailViewController.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Reply/ViewControllers/ReplyDetailViewController.swift
@@ -178,6 +178,7 @@ private extension ReplyDetailViewController {
             self.nickname = data.nickname
             self.rootView.bindData(nickname: data.nickname, content: data.content)
             self.judgeIsAlert(isRead: data.isRead)
+            AppStoreReviewManager.markReplyAsViewed()
         }
     }
 }


### PR DESCRIPTION
## 🍀 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- (업데이트 이후 신규 + 기존 유저 모두) 첫 답장 조회 시 인앱 리뷰 요청 팝업 띄우기

## 🚀 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
### enum AppStoreReviewManager 구현하여 static하게 사용할 수 있도록 함
<img width="654" alt="image" src="https://github.com/user-attachments/assets/7a4ddb27-0d37-4186-9991-255b49cf746b" />

- 로직 처리에는 두 가지 `UserDefaults`에 저장되는 Bool 변수가 사용됨
  - `hasRequestedReview_Key` : 리뷰 요청한 적 있는지
  - `hasViewedReply_Key` : 답장 조회한 적 있는지
  - 그래서 아래처럼 `!hasRequestedReview && hasViewedReply`(리뷰 요청한 적은 ❌, 답장 조회한 적은 ⭕️)일 때 리뷰 요청함!!
<img width="820" alt="image" src="https://github.com/user-attachments/assets/3955592c-bd24-4f6c-8f28-6661f563a4fd" />


## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 일반 답장 조회 | <img width = "300" src = "https://github.com/user-attachments/assets/9fb2706f-896d-42d8-bf34-a24e59652bb0" /> |
| 일기 작성 후 답장 조회 | <img width = "300" src = "https://github.com/user-attachments/assets/1c6a9785-e9be-464b-93ea-9372f6c78ffb" /> |

## ✅ CheckList
- [x] 오류 없이 빌드되는지 확인
- [x] 로그용 print문 제거
- [x] 불필요한 주석 제거
- [x] 코드 컨벤션 확인

### 🔗 Issue 
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #114
