### PR TITLE
Feat [#118] 이어쓰기 알림설정 바텀시트 비즈니스 로직 구현

### DIFF
--- a/Clody_iOS/Clody_iOS/Global/Literals/String.swift
+++ b/Clody_iOS/Clody_iOS/Global/Literals/String.swift
@@ -48,6 +48,7 @@ enum I18N {
         static let alarm = "설정 > 알림 > 클로디에서 알림을 켜주세요."
         static let changeComplete = "변경을 완료했어요."
         static let notificationTimeChangeComplete = "알림 시간 설정을 완료했어요."
+        static let continueWritingAlarmChangeComplete = "이어쓰기 알림 설정을 완료했어요."
     }
     
     enum BottomSheet {

--- a/Clody_iOS/Clody_iOS/Global/Manager/UserManager.swift
+++ b/Clody_iOS/Clody_iOS/Global/Manager/UserManager.swift
@@ -47,6 +47,11 @@ final class UserManager {
         set { keychain["appleEmail"] = newValue }
     }
     
+    var hasViewedDraftAlarmBottomSheet: Bool {
+        get { UserDefaults.standard.bool(forKey: "hasViewedDraftAlarmBottomSheet") }
+        set { UserDefaults.standard.set(newValue, forKey: "hasViewedDraftAlarmBottomSheet") }
+    }
+    
     var hasAccessToken: Bool { return self.accessToken != nil }
     var accessTokenValue: String { return self.accessToken ?? "" }
     var refreshTokenValue: String { return self.refreshToken ?? "" }

--- a/Clody_iOS/Clody_iOS/Presentation/Calendar/ViewControllers/CalendarViewController.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Calendar/ViewControllers/CalendarViewController.swift
@@ -18,9 +18,11 @@ final class CalendarViewController: UIViewController {
     // MARK: - Properties
     
     private let viewModel = CalendarViewModel()
+    private let notificationViewModel = NotificationViewModel()
     private let disposeBag = DisposeBag()
     private let tapDateRelay = PublishRelay<Date>()
     private let currentPageChanged = PublishRelay<(year: Int, month: Int)>()
+    private lazy var notificationStateRelay = BehaviorRelay<NotificationState>(value: NotificationState())
     private var calendarData: [MonthlyDiary] {
         viewModel.monthlyCalendarDataRelay.value.diaries
     }
@@ -49,7 +51,7 @@ final class CalendarViewController: UIViewController {
         super.viewWillAppear(animated)
         
         AppStoreReviewManager.requestReviewIfNeeded()
-        viewModel.fetchData()
+        fetchData()
     }
     
     override func viewDidLoad() {
@@ -297,6 +299,22 @@ private extension CalendarViewController {
             .disposed(by: disposeBag)
     }
     
+    func fetchData() {
+        viewModel.fetchData()
+        if !UserManager.shared.hasViewedDraftAlarmBottomSheet {
+            notificationViewModel.getAlarmInfo() { [weak self] data in
+                guard let self = self else { return }
+                let notificationState = NotificationState(
+                    isDiaryWritingAlarmOn: data.isDiaryAlarm,
+                    isContinueWritingAlarmOn: data.isDraftAlarm,
+                    alarmTime: data.time,
+                    isReplyAlarmOn: data.isReplyAlarm
+                )
+                notificationStateRelay.accept(notificationState)
+            }
+        }
+    }
+    
     func setDelegate() {
         rootView.mainCalendarView.delegate = self
         rootView.mainCalendarView.dataSource = self
@@ -310,8 +328,10 @@ private extension CalendarViewController {
     func setUI() {
         self.navigationController?.isNavigationBarHidden = true
         setupDeleteBottomSheet()
-        setupDraftAlarmBottomSheet()
         setupPickerView()
+        if !UserManager.shared.hasViewedDraftAlarmBottomSheet {
+            setupDraftAlarmBottomSheet()
+        }
     }
     
     func setupDeleteBottomSheet() {

--- a/Clody_iOS/Clody_iOS/Presentation/Calendar/ViewControllers/CalendarViewController.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Calendar/ViewControllers/CalendarViewController.swift
@@ -370,7 +370,15 @@ private extension CalendarViewController {
                 guard let self = self else { return }
                 dismissBottomSheet(continueWritingAlarmBottomSheet, animated: true)
                 
-                // TODO: 알림 설정 API 호출
+                var notificationState = notificationStateRelay.value
+                notificationState.isContinueWritingAlarmOn = true
+                if !notificationState.isDiaryWritingAlarmOn {
+                    notificationState.alarmTime = "21:30"
+                }
+                notificationViewModel.postAlarmSetting(notificationState) { [weak self] _ in
+                    // TODO: 토스트메시지
+                    self?.notificationStateRelay.accept(notificationState)
+                }
             })
             .disposed(by: self.disposeBag)
         

--- a/Clody_iOS/Clody_iOS/Presentation/Calendar/ViewControllers/CalendarViewController.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Calendar/ViewControllers/CalendarViewController.swift
@@ -29,6 +29,9 @@ final class CalendarViewController: UIViewController {
     private var hasDailyDiary : Bool {
         viewModel.dailyDiaryDataRelay.value.diaries.count != 0
     }
+    private var hasViewedDraftAlarmBottomSheet: Bool {
+        UserManager.shared.hasViewedDraftAlarmBottomSheet
+    }
     
     // MARK: - UI Components
     
@@ -230,7 +233,14 @@ private extension CalendarViewController {
                 } else {
                     /// 일기 작성
                     AmplitudeManager.shared.trackEvent("home_writing_diary")
-                    navigationController?.pushViewController(WritingDiaryViewController(date: date), animated: true)
+                    let writingDiaryViewController = WritingDiaryViewController(
+                        date: date,
+                        firstDraftSaveCompletion: hasViewedDraftAlarmBottomSheet ? nil : { [weak self] in
+                            guard let self = self else { return }
+                            presentBottomSheet(continueWritingAlarmBottomSheet)
+                        }
+                    )
+                    navigationController?.pushViewController(writingDiaryViewController, animated: true)
                 }
             })
             .disposed(by: disposeBag)
@@ -301,7 +311,7 @@ private extension CalendarViewController {
     
     func fetchData() {
         viewModel.fetchData()
-        if !UserManager.shared.hasViewedDraftAlarmBottomSheet {
+        if !hasViewedDraftAlarmBottomSheet {
             notificationViewModel.getAlarmInfo() { [weak self] data in
                 guard let self = self else { return }
                 let notificationState = NotificationState(
@@ -329,7 +339,7 @@ private extension CalendarViewController {
         self.navigationController?.isNavigationBarHidden = true
         setupDeleteBottomSheet()
         setupPickerView()
-        if !UserManager.shared.hasViewedDraftAlarmBottomSheet {
+        if !hasViewedDraftAlarmBottomSheet {
             setupDraftAlarmBottomSheet()
         }
     }
@@ -369,6 +379,7 @@ private extension CalendarViewController {
             .subscribe(onNext: { [weak self] _ in
                 guard let self = self else { return }
                 dismissBottomSheet(continueWritingAlarmBottomSheet, animated: true)
+                UserManager.shared.hasViewedDraftAlarmBottomSheet = true
                 
                 var notificationState = notificationStateRelay.value
                 notificationState.isContinueWritingAlarmOn = true
@@ -386,6 +397,7 @@ private extension CalendarViewController {
             .subscribe(onNext: { [weak self] _ in
                 guard let self = self else { return }
                 dismissBottomSheet(continueWritingAlarmBottomSheet, animated: true)
+                UserManager.shared.hasViewedDraftAlarmBottomSheet = true
             })
             .disposed(by: self.disposeBag)
     }

--- a/Clody_iOS/Clody_iOS/Presentation/Calendar/ViewControllers/CalendarViewController.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Calendar/ViewControllers/CalendarViewController.swift
@@ -387,8 +387,9 @@ private extension CalendarViewController {
                     notificationState.alarmTime = "21:30"
                 }
                 notificationViewModel.postAlarmSetting(notificationState) { [weak self] _ in
-                    // TODO: 토스트메시지
-                    self?.notificationStateRelay.accept(notificationState)
+                    guard let self = self else { return }
+                    ClodyToast.show(toastType: .continueWritingAlarmChangeComplete)
+                    notificationStateRelay.accept(notificationState)
                 }
             })
             .disposed(by: self.disposeBag)

--- a/Clody_iOS/Clody_iOS/Presentation/Common/Component/ClodyToast.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Common/Component/ClodyToast.swift
@@ -15,6 +15,7 @@ enum ToastType {
     case alarm
     case changeComplete
     case notificationTimeChangeComplete
+    case continueWritingAlarmChangeComplete
 }
 
 final class ClodyToast {

--- a/Clody_iOS/Clody_iOS/Presentation/Common/Component/ClodyToast.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Common/Component/ClodyToast.swift
@@ -16,6 +16,17 @@ enum ToastType {
     case changeComplete
     case notificationTimeChangeComplete
     case continueWritingAlarmChangeComplete
+    
+    var message: String {
+        switch self {
+        case .needToWriteAll: return I18N.Toast.needToWriteAll
+        case .limitFive: return I18N.Toast.limitFive
+        case .alarm: return I18N.Toast.alarm
+        case .changeComplete: return I18N.Toast.changeComplete
+        case .notificationTimeChangeComplete: return I18N.Toast.notificationTimeChangeComplete
+        case .continueWritingAlarmChangeComplete: return I18N.Toast.continueWritingAlarmChangeComplete
+        }
+    }
 }
 
 final class ClodyToast {

--- a/Clody_iOS/Clody_iOS/Presentation/Common/Component/ClodyToastView.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Common/Component/ClodyToastView.swift
@@ -70,20 +70,7 @@ final class ClodyToastView: BaseView {
     }
     
     func bindData(toastType: ToastType) {
-        switch toastType {
-        case .needToWriteAll:
-            titleText = I18N.Toast.needToWriteAll
-        case .limitFive:
-            titleText = I18N.Toast.limitFive
-        case .alarm:
-            titleText = I18N.Toast.alarm
-        case .changeComplete:
-            titleText = I18N.Toast.changeComplete
-        case .notificationTimeChangeComplete:
-            titleText = I18N.Toast.notificationTimeChangeComplete
-        }
-        
-        textLabel.attributedText = UIFont.pretendardString(text: titleText, style: .body4_semibold)
+        textLabel.attributedText = UIFont.pretendardString(text: toastType.message, style: .body4_semibold)
         textLabel.sizeToFit()
         updateConstraint()
         layoutIfNeeded()

--- a/Clody_iOS/Clody_iOS/Presentation/WritingDiary/ViewControllers/WritingDiaryViewController.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/WritingDiary/ViewControllers/WritingDiaryViewController.swift
@@ -26,6 +26,7 @@ final class WritingDiaryViewController: UIViewController {
     private var textViewHeight: CGFloat = 0
     private var currentKeyboardVisible: Bool = false
     private var isAddButtonEnabled: Bool = true
+    private let firstDraftSaveCompletion: (() -> Void)?
     
     // MARK: - UI Components
     
@@ -37,8 +38,9 @@ final class WritingDiaryViewController: UIViewController {
     
     // MARK: - Life Cycles
     
-    init(date: Date) {
+    init(date: Date, firstDraftSaveCompletion: (() -> Void)? = nil) {
         self.date = date
+        self.firstDraftSaveCompletion = firstDraftSaveCompletion
         
         super.init(nibName: nil, bundle: nil)
     }
@@ -95,6 +97,8 @@ private extension WritingDiaryViewController {
         output.popToCalendar
             .emit(onNext: { [weak self] in
                 self?.navigationController?.popViewController(animated: true)
+                // TODO: 임시저장 후 pop될 때 시점으로 변경
+                self?.firstDraftSaveCompletion?()
                 AmplitudeManager.shared.trackEvent("writing_diary_back")
             })
             .disposed(by: disposeBag)

--- a/Clody_iOS/Clody_iOS/Presentation/WritingDiary/ViewControllers/WritingDiaryViewController.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/WritingDiary/ViewControllers/WritingDiaryViewController.swift
@@ -213,16 +213,16 @@ private extension WritingDiaryViewController {
                 alert?.leftButton.rx.tap
                     .subscribe(onNext: { [weak self] in
                         guard let self = self else { return }
-                        showLoadingIndicator()
                         let hasEmpty = viewModel.diariesRelay.value.contains("")
-
                         if hasEmpty {
                             ClodyToast.show(toastType: .needToWriteAll)
                             hideAlert()
                             return
                         }
                         
+                        showLoadingIndicator()
                         let dateString = DateFormatter.string(from: date, format: "yyyy-MM-dd")
+                        
                         viewModel.postDraftDiary(
                             date: dateString,
                             content: viewModel.diariesRelay.value


### PR DESCRIPTION
## 🍀 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- ⭐️ 일기 작성 화면에서 임시저장 후 홈으로 돌아오면 최초 1회 이어쓰기 알림설정 바텀시트 띄우기 구현
  - 일기 작성 화면 -> 홈화면 돌아오는 시점 클로저로 연결
  - 알림 받기 버튼 누르면 postAlarmSetting API 호출
  - 그래서 바텀시트 띄운 적 없으면 홈화면에서 getAlarmInfo API 호출해서 알림 설정 데이터 받아옴
  -> 기존 정보를 알아야 이어쓰기 알림 설정할 때 그것만 바꿀 수 있음
- weak self 필요한 곳 붙여줌
- 불필요한 self 지움
- 코드 간결하게 수정 등...

## 🚀 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
### 1️⃣ UserManager에 이어쓰기 알림설정 바텀시트 본 적 있는지 Bool값 `hasViewedDraftAlarmBottomSheet` 만듦
<img width="855" alt="image" src="https://github.com/user-attachments/assets/8342a628-6fb6-4b15-9e3f-59f46f68dfcf" />

- UserDefaults에서 관리합니다.
- false라면(아직 본 적 없으면) 홈화면에서 바텀시트 미리 준비 + viewWillAppear 때 getAlarmInfo 호출해서 기존 알림 데이터 가져옴
### 2️⃣ 일기 작성 화면(WritingDiaryViewController) 생성자에 `firstDraftSaveCompletion` 클로저 파라미터 넣음
<img width="583" alt="image" src="https://github.com/user-attachments/assets/6e128f32-975e-4949-aff9-c72ffb4bc145" />
<img width="811" alt="image" src="https://github.com/user-attachments/assets/861a394e-c418-453e-833b-f87f13936fb8" />

- 홈화면 이어쓰기 버튼 탭 
-> `hasViewedDraftAlarmBottomSheet` 확인
-> 아직 바텀시트 본 적 없으면!! -> `firstDraftSaveCompletion` 파라미터에 작성된 클로저(present 바텀시트) 실행됨 (임시저장하고 홈 돌아왔을 때)
-> 본 적 있으면 nil -> 아무일도 안 일어남. 당연함
<img width="624" alt="image" src="https://github.com/user-attachments/assets/29640697-d7c2-47d2-b685-3a0412c4ace7" />

- 일기 작성 화면에서 임시저장 성공 후 `firstDraftSaveCompletion` 클로저가 실행됩니다.

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 이어쓰기 알림 설정 | <img width = "350" src = "https://github.com/user-attachments/assets/24ffd3db-e46d-4d1c-aca9-ce140bfe0b81" /> |

## ✅ CheckList
- [ ] 오류 없이 빌드되는지 확인
- [ ] 로그용 print문 제거
- [ ] 불필요한 주석 제거
- [ ] 코드 컨벤션 확인

### 🔗 Issue 
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #118
