### PR TITLE
Network [#124] 자동 로그인 조건문 변경, 404 에러 대응 및 경고 해결

### DIFF
--- a/Clody_iOS/Clody_iOS.xcodeproj/project.pbxproj
+++ b/Clody_iOS/Clody_iOS.xcodeproj/project.pbxproj
@@ -1114,6 +1114,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		0BCE8F772C908CB200356F53 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/Clody_iOS/Clody_iOS.xcodeproj/project.pbxproj
+++ b/Clody_iOS/Clody_iOS.xcodeproj/project.pbxproj
@@ -1052,7 +1052,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1530;
-				LastUpgradeCheck = 1530;
+				LastUpgradeCheck = 1640;
 				TargetAttributes = {
 					0B20F3D82C2C4DAA00F8D62D = {
 						CreatedOnToolsVersion = 15.3;
@@ -1328,6 +1328,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = GKV299JR6D;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -1392,6 +1393,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = GKV299JR6D;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -1425,7 +1427,6 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				"DEBUG_INFORMATION_FORMAT[sdk=*]" = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = GKV299JR6D;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Clody_iOS/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -1461,7 +1462,6 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = GKV299JR6D;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Clody_iOS/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/Clody_iOS/Clody_iOS.xcodeproj/project.pbxproj
+++ b/Clody_iOS/Clody_iOS.xcodeproj/project.pbxproj
@@ -1425,7 +1425,7 @@
 				CODE_SIGN_ENTITLEMENTS = Clody_iOS/Clody_iOS.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				"DEBUG_INFORMATION_FORMAT[sdk=*]" = "dwarf-with-dsym";
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1462,7 +1462,7 @@
 				CODE_SIGN_ENTITLEMENTS = Clody_iOS/Clody_iOS.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Clody_iOS/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/Clody_iOS/Clody_iOS.xcodeproj/xcshareddata/xcschemes/Clody_iOS.xcscheme
+++ b/Clody_iOS/Clody_iOS.xcodeproj/xcshareddata/xcschemes/Clody_iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1530"
+   LastUpgradeVersion = "1640"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Clody_iOS/Clody_iOS.xcodeproj/xcshareddata/xcschemes/Clody_iOS_Dev.xcscheme
+++ b/Clody_iOS/Clody_iOS.xcodeproj/xcshareddata/xcschemes/Clody_iOS_Dev.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1530"
+   LastUpgradeVersion = "1640"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Clody_iOS/Clody_iOS/Application/AppDelegate.swift
+++ b/Clody_iOS/Clody_iOS/Application/AppDelegate.swift
@@ -82,7 +82,6 @@ extension AppDelegate: MessagingDelegate {
         print("Firebase registration token: \(String(describing: fcmToken))")
         if let fcmToken {
             UserManager.shared.updateFcmToken(fcmToken)
-            UserManager.shared.clearAll()
         }
 
         let dataDict: [String: String] = ["token": fcmToken ?? ""]

--- a/Clody_iOS/Clody_iOS/Application/AppDelegate.swift
+++ b/Clody_iOS/Clody_iOS/Application/AppDelegate.swift
@@ -77,12 +77,12 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 }
 
 extension AppDelegate: MessagingDelegate {
-    
     // 파이어베이스 MessagingDelegate 설정
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
         print("Firebase registration token: \(String(describing: fcmToken))")
         if let fcmToken {
             UserManager.shared.updateFcmToken(fcmToken)
+            UserManager.shared.clearAll()
         }
 
         let dataDict: [String: String] = ["token": fcmToken ?? ""]

--- a/Clody_iOS/Clody_iOS/Application/SceneDelegate.swift
+++ b/Clody_iOS/Clody_iOS/Application/SceneDelegate.swift
@@ -33,12 +33,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         print("RefreshToken: 🍒\(UserManager.shared.refreshTokenValue)")
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            DispatchQueue.main.async {
-                if UserManager.shared.hasAccessToken {
-                    self.window?.rootViewController = UINavigationController(rootViewController: CalendarViewController())
-                } else {
-                    self.window?.rootViewController = UINavigationController(rootViewController: LoginViewController())
-                }
+            if UserManager.shared.isAutoLoginEnabled {
+                self.window?.rootViewController = UINavigationController(rootViewController: CalendarViewController())
+            } else {
+                UserManager.shared.clearAll()
+                self.window?.rootViewController = UINavigationController(rootViewController: LoginViewController())
             }
         }
     }

--- a/Clody_iOS/Clody_iOS/Application/SceneDelegate.swift
+++ b/Clody_iOS/Clody_iOS/Application/SceneDelegate.swift
@@ -31,6 +31,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     func proceedToNextViewController() {
         print("RefreshToken: 🍒\(UserManager.shared.refreshTokenValue)")
+        UserManager.shared.clearAll()
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             DispatchQueue.main.async {

--- a/Clody_iOS/Clody_iOS/Application/SceneDelegate.swift
+++ b/Clody_iOS/Clody_iOS/Application/SceneDelegate.swift
@@ -31,7 +31,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     func proceedToNextViewController() {
         print("RefreshToken: 🍒\(UserManager.shared.refreshTokenValue)")
-        UserManager.shared.clearAll()
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             DispatchQueue.main.async {

--- a/Clody_iOS/Clody_iOS/Global/Manager/AppVersionManager.swift
+++ b/Clody_iOS/Clody_iOS/Global/Manager/AppVersionManager.swift
@@ -70,7 +70,8 @@ class AppVersionManager {
     }
     
     private func showForceUpdateAlert(appStoreVersion: String) {
-        guard let topViewController = UIApplication.shared.windows.first?.rootViewController else { return }
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let topViewController = windowScene.windows.first?.rootViewController else { return }
         
         let alert = UIAlertController(
             title: "필수 업데이트",
@@ -93,7 +94,8 @@ class AppVersionManager {
     }
     
     private func showOptionalUpdateAlert(appStoreVersion: String, completion: @escaping (Bool) -> Void) {
-        guard let topViewController = UIApplication.shared.keyWindow?.rootViewController else { return }
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let topViewController = windowScene.windows.first?.rootViewController else { return }
         
         let alert = UIAlertController(title: "업데이트 필요",
                                       message: "새로운 버전 \(appStoreVersion)을 사용할 수 있습니다. 지금 업데이트하시겠습니까?",

--- a/Clody_iOS/Clody_iOS/Global/Manager/UserManager.swift
+++ b/Clody_iOS/Clody_iOS/Global/Manager/UserManager.swift
@@ -52,7 +52,12 @@ final class UserManager {
         set { UserDefaults.standard.set(newValue, forKey: "hasViewedDraftAlarmBottomSheet") }
     }
     
-    var hasAccessToken: Bool { return self.accessToken != nil }
+    var isAutoLoginEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: "isAutoLoginEnabled") && hasAccessToken }
+        set { UserDefaults.standard.set(newValue, forKey: "isAutoLoginEnabled") }
+    }
+    
+    private var hasAccessToken: Bool { return self.accessToken != nil }
     var accessTokenValue: String { return self.accessToken ?? "" }
     var refreshTokenValue: String { return self.refreshToken ?? "" }
     var authCodeValue: String { return self.authCode ?? "" }
@@ -63,9 +68,11 @@ final class UserManager {
 }
 
 extension UserManager {
+    
     func updateToken(_ accessToken: String, _ refreshToken: String) {
         self.accessToken = accessToken
         self.refreshToken = refreshToken
+        isAutoLoginEnabled = true
     }
     
     func updateFcmToken(_ fcmToken: String) {
@@ -73,9 +80,10 @@ extension UserManager {
     }
     
     func clearAll() {
-        self.accessToken = nil
-        self.refreshToken = nil
-        self.idToken = nil
-        self.platform = nil
+        accessToken = nil
+        refreshToken = nil
+        idToken = nil
+        platform = nil
+        isAutoLoginEnabled = false
     }
 }

--- a/Clody_iOS/Clody_iOS/Global/Manager/UserManager.swift
+++ b/Clody_iOS/Clody_iOS/Global/Manager/UserManager.swift
@@ -25,8 +25,6 @@ final class UserManager {
         set { keychain["refreshToken"] = newValue }
     }
     
-    var authCode: String?
-    
     var idToken: String? {
         get { return keychain["idToken"] }
         set { keychain["idToken"] = newValue }
@@ -60,7 +58,6 @@ final class UserManager {
     private var hasAccessToken: Bool { return self.accessToken != nil }
     var accessTokenValue: String { return self.accessToken ?? "" }
     var refreshTokenValue: String { return self.refreshToken ?? "" }
-    var authCodeValue: String { return self.authCode ?? "" }
     var idTokenValue: String { return self.idToken ?? "" }
     var platformValue: String { return self.platform ?? "" }
     var fcmTokenValue: String { return self.fcmToken ?? "" }

--- a/Clody_iOS/Clody_iOS/Network/Base/AuthIntercepter.swift
+++ b/Clody_iOS/Clody_iOS/Network/Base/AuthIntercepter.swift
@@ -10,11 +10,11 @@ import UIKit
 import Alamofire
 import Moya
 
-///// 토큰 만료 시 자동으로 refresh를 위한 서버 통신
+/// 토큰 관련 사용자 인증 관리 및 토큰 만료 시 자동으로 refresh를 위한 서버 통신
 final class AuthInterceptor: RequestInterceptor {
-    
-    private var retryLimit = 2
     static let shared = AuthInterceptor()
+    
+    private let retryLimit = 2
     
     private init() {}
     
@@ -45,7 +45,14 @@ final class AuthInterceptor: RequestInterceptor {
             return
         }
         
-        guard let response = request.response, response.statusCode == 401 else {
+        guard let response = request.response else { return completion(.doNotRetryWithError(error)) }
+        
+        if response.statusCode == 404 {
+            print("❗️[404] 존재하지 않는 유저입니다❗️")
+            handleTokenFailure(completion: completion, error: error)
+        }
+        
+        guard response.statusCode == 401 else {
             completion(.doNotRetryWithError(error))
             return
         }
@@ -61,20 +68,20 @@ final class AuthInterceptor: RequestInterceptor {
                         completion(.retry)
                     } else {
                         print("🚨토큰 데이터가 없습니다🚨")
-                        self.handleTokenRefreshFailure(completion: completion, error: error)
+                        self.handleTokenFailure(completion: completion, error: error)
                     }
                 } else {
                     print("🚨토큰 재발급에 실패했습니다🚨")
-                    self.handleTokenRefreshFailure(completion: completion, error: error)
+                    self.handleTokenFailure(completion: completion, error: error)
                 }
             case .failure(let moyaError):
                 print("🚨토큰 재발급 중 오류 발생: \(moyaError)🚨")
-                self.handleTokenRefreshFailure(completion: completion, error: moyaError)
+                self.handleTokenFailure(completion: completion, error: moyaError)
             }
         }
     }
     
-    private func handleTokenRefreshFailure(completion: @escaping (RetryResult) -> Void, error: Error) {
+    private func handleTokenFailure(completion: @escaping (RetryResult) -> Void, error: Error) {
         UserManager.shared.clearAll()
         if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
             sceneDelegate.changeRootViewController(LoginViewController(), animated: true)

--- a/Clody_iOS/Clody_iOS/Network/Base/AuthIntercepter.swift
+++ b/Clody_iOS/Clody_iOS/Network/Base/AuthIntercepter.swift
@@ -45,16 +45,8 @@ final class AuthInterceptor: RequestInterceptor {
             return
         }
         
-        guard let response = request.response else { return completion(.doNotRetryWithError(error)) }
-        
-        if response.statusCode == 404 {
-            print("❗️[404] 존재하지 않는 유저입니다❗️")
-            handleTokenFailure(completion: completion, error: error)
-        }
-        
-        guard response.statusCode == 401 else {
-            completion(.doNotRetryWithError(error))
-            return
+        guard let response = request.response, response.statusCode == 401 else {
+            return completion(.doNotRetryWithError(error))
         }
         
         let provider = MoyaProvider<AuthRouter>()

--- a/Clody_iOS/Clody_iOS/Presentation/Common/Component/ClodyToast.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Common/Component/ClodyToast.swift
@@ -45,7 +45,7 @@ final class ClodyToast {
         window.addSubview(toastView)
         
         toastView.snp.makeConstraints {
-            $0.bottom.equalToSuperview().inset(ScreenUtils.getHeight(38))
+            $0.bottom.equalToSuperview().inset(window.safeAreaInsets.bottom + ScreenUtils.getHeight(6))
             $0.centerX.equalToSuperview()
         }
         

--- a/Clody_iOS/Clody_iOS/Presentation/List/ViewControllers/ListViewController.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/List/ViewControllers/ListViewController.swift
@@ -91,10 +91,8 @@ private extension ListViewController {
         output.replyDate
             .drive(onNext: { [weak self] date in
                 guard let self = self else { return }
-                let dateData = DateFormatter.date(from: date)
-                let diaryStatus = viewModel.listDataRelay.value.diaries.first(where: { $0.date == date})?.replyStatus
-                
                 AmplitudeManager.shared.trackEvent("list_reply")
+                let dateData = DateFormatter.date(from: date)
                 self.navigationController?.pushViewController(ReplyWaitingViewController(date: dateData ?? Date(), isHomeBackButton: false), animated: true)
             })
             .disposed(by: disposeBag)

--- a/Clody_iOS/Clody_iOS/Presentation/List/ViewModels/ListViewModel.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/List/ViewModels/ListViewModel.swift
@@ -69,8 +69,6 @@ final class ListViewModel: ViewModelType {
         
         let changeToCalendar = input.tapCalendarButton.asSignal()
         
-        let showDeleteBottomSheet = input.tapKebabButton.asSignal()
-        
         let showPickerView = input.tapDateButton.asSignal()
         
         let changeNavigationDate = selectedMonthRelay
@@ -151,7 +149,6 @@ extension ListViewModel {
         provider.request(target: .deleteDiary(year: year, month: month, date: date), instance: BaseResponse<EmptyResponseDTO>.self, completion: { data in
             switch data.status {
             case 200..<300:
-                guard let data = data.data else { return }
                 self.getListData(year: year, month: month)
             case -1:
                 self.errorStatusRelay.accept("networkView")

--- a/Clody_iOS/Clody_iOS/Presentation/Setting/ViewControllers/AccountViewController.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Setting/ViewControllers/AccountViewController.swift
@@ -199,6 +199,10 @@ final class AccountViewController: UIViewController {
                 self.hideLoadingIndicator()
                 
                 switch networkViewJudge {
+                case .login:
+                    if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
+                        sceneDelegate.changeRootViewController(LoginViewController(), animated: true)
+                    }
                 case .network:
                     self.showRetryView(isNetworkError: true) {
                         self.getUserInfo()

--- a/Clody_iOS/Clody_iOS/Presentation/Setting/ViewModels/AccountViewModel.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Setting/ViewModels/AccountViewModel.swift
@@ -29,7 +29,14 @@ final class AccountViewModel: ViewModelType {
         let popViewController: Driver<Void>
     }
     
-    let getUserInfoErrorStatus = PublishRelay<NetworkViewJudge>()
+    enum NetworkUserInfoViewJudge {
+        case success
+        case network
+        case unknowned
+        case login
+    }
+    
+    let getUserInfoErrorStatus = PublishRelay<NetworkUserInfoViewJudge>()
     let patchNicknameErrorStatus = PublishRelay<NetworkViewJudge>()
     
     func transform(from input: Input, disposeBag: RxSwift.DisposeBag) -> Output {
@@ -85,6 +92,10 @@ extension AccountViewModel {
                 guard let data = response.data else { return }
                 self.getUserInfoErrorStatus.accept(.success)
                 completion(data)
+            case 404:
+                print("❗️[404] 존재하지 않는 유저입니다❗️")
+                UserManager.shared.clearAll()
+                self.getUserInfoErrorStatus.accept(.login)
             case -1:
                 self.getUserInfoErrorStatus.accept(.network)
             default:


### PR DESCRIPTION
## 🍀 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 노란 경고 뜨는 거 해결(deprecated, run script 등)
- 🌟 자동 로그인 조건문 변경 (isAutoLoginEnabled: 자동로그인 활성화 Bool 변수 추가)
  - 앱 삭제 시, 자동로그인 비활성화 처리됨. (재설치 후 토큰이 저장돼 있어도 자동 로그인 안 됨)
- 프로필 조회 시 404 에러 대응 -> 로그인 화면으로 이동
- 토스트 메시지 UI 디테일 수정

## 🚀 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- 서버에서 아직 프로필 조회 시 존재하지 않는 사용자에 대해 404 에러가 아닌 500 에러 응답 주긴함 (서버에서 수정해주면 그때 다시 테스트해봐야 할듯)

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 앱 삭제 시 자동로그인 비활성화 처리 | 아래 mp4 |

https://github.com/user-attachments/assets/4981335b-8070-435e-86ba-0c791cd54773


## ✅ CheckList
- [ ] 오류 없이 빌드되는지 확인
- [ ] 로그용 print문 제거
- [ ] 불필요한 주석 제거
- [ ] 코드 컨벤션 확인

### 🔗 Issue 
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #124
