### PR TITLE
Fix [#126] v1.2.0 버전 QA사항 반영

### DIFF
--- a/Clody_iOS/Clody_iOS/Presentation/Calendar/ViewControllers/CalendarViewController.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Calendar/ViewControllers/CalendarViewController.swift
@@ -224,28 +224,31 @@ private extension CalendarViewController {
                 switch status {
                 case .writeEnabled:
                     AmplitudeManager.shared.trackEvent("home_writing_diary")
-                    navigationController?.pushViewController(WritingDiaryViewController(date: date, isFromDraft: false), animated: true)
+                    pushWritingDiaryVC(isFromDraft: false)
                 case .replyEnabled:
                     AmplitudeManager.shared.trackEvent("home_reply")
                     navigationController?.pushViewController(ReplyWaitingViewController(date: date, isHomeBackButton: false), animated: true)
                 case .draftEnabled:
                     if date.isWritingAvailable {
                         AmplitudeManager.shared.trackEvent("home_writing_diary")
-                        
-                        let writingDiaryViewController = WritingDiaryViewController(
-                            date: date,
-                            isFromDraft: true,
-                            firstDraftSaveCompletion: hasViewedDraftAlarmBottomSheet ? nil : { [weak self] in
-                                guard let self = self else { return }
-                                presentBottomSheet(continueWritingAlarmBottomSheet)
-                            }
-                        )
-                        navigationController?.pushViewController(writingDiaryViewController, animated: true)
+                        pushWritingDiaryVC(isFromDraft: true)
                     } else {
                         showNoReplyDraftAlert(currentDate: date)
                     }
                 default:
                     print("navigate error")
+                }
+                
+                func pushWritingDiaryVC(isFromDraft: Bool) {
+                    let writingDiaryViewController = WritingDiaryViewController(
+                        date: date,
+                        isFromDraft: isFromDraft,
+                        firstDraftSaveCompletion: hasViewedDraftAlarmBottomSheet ? nil : { [weak self] in
+                            guard let self = self else { return }
+                            presentBottomSheet(continueWritingAlarmBottomSheet)
+                        }
+                    )
+                    navigationController?.pushViewController(writingDiaryViewController, animated: true)
                 }
             })
             .disposed(by: disposeBag)

--- a/Clody_iOS/Clody_iOS/Presentation/Reply/ViewControllers/ReplyWaitingViewController.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Reply/ViewControllers/ReplyWaitingViewController.swift
@@ -179,7 +179,7 @@ private extension ReplyWaitingViewController {
             .drive(onNext: { [weak self] in
                 guard let self = self else { return }
                 AmplitudeManager.shared.trackEvent("waiting_diary_reply")
-                totalSecondsSubject.onNext(0)
+                totalSecondsSubject.onCompleted()
                 adLoadCompletionSubject.onCompleted()
                 pushViewController(date: date)
             })
@@ -188,7 +188,7 @@ private extension ReplyWaitingViewController {
         output.popViewController
             .drive(onNext: { [weak self] in
                 guard let self = self else { return }
-                totalSecondsSubject.onNext(0)
+                totalSecondsSubject.onCompleted()
                 adLoadCompletionSubject.onCompleted()
                 
                 if isHomeBackButton {

--- a/Clody_iOS/Clody_iOS/Presentation/WritingDiary/ViewControllers/WritingDiaryViewController.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/WritingDiary/ViewControllers/WritingDiaryViewController.swift
@@ -283,13 +283,6 @@ private extension WritingDiaryViewController {
                 alert?.leftButton.rx.tap
                     .subscribe(onNext: { [weak self] in
                         guard let self = self else { return }
-                        
-                        if !viewModel.hasAnyContent() {
-                            ClodyToast.show(toastType: .needToWriteAll)
-                            hideAlert()
-                            return
-                        }
-                        
                         showLoadingIndicator()
                         let dateString = DateFormatter.string(from: date, format: "yyyy-MM-dd")
                         


### PR DESCRIPTION
## 🍀 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 최초 임시저장 후 홈화면에서 이어쓰기 알림설정 바텀시트 뜨지 않는 문제 해결
- 일기작성 시 빈값만 있어도 임시저장 되도록 수정
  - 기존에는 빈값만 있으면 토스트 메시지 뜨면서 임시저장 안 됨

## 🚀 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
### 🌻 오늘의 교훈 : enum의 모든 케이스를 유심히 살펴보자...
- 기존에 최초 1회가 아닌 임시저장 2회, 3회 후 뜨게 된 원인 ㅋㅋ 
- => 홈화면 하단 버튼 state가 `.draftEnabled`(이어쓰기) 일 때만 일기작성 뷰컨 push될 때 바텀시트 뜨도록 설정해놨기 때문;;
그니까 당연히 임시저장 2회부터 떴던 것이다. 완전 바보같음 ㅠ🤨
- 결론: 홈화면 하단 버튼 state가 `.writeEnabled`(일기 쓰기) 일 때도 설정해놓음!!

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 문제: 빈값만 있을 때 임시저장 안 됨 | <img width = "300" src = "https://github.com/user-attachments/assets/444955a2-5375-4d80-b917-9a6760c5095f" /> |
| 해결: 빈값만 있어도 (이니셜 임시저장 값과 다르면) 가능 | <img width = "300" src = "https://github.com/user-attachments/assets/17f82d7d-25fb-479b-a8b9-31ff7400aa37" /> |

## ✅ CheckList
- [ ] 오류 없이 빌드되는지 확인
- [ ] 로그용 print문 제거
- [ ] 불필요한 주석 제거
- [ ] 코드 컨벤션 확인

### 🔗 Issue 
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #126
