### PR TITLE
Fix [#128] 업데이트 Alert를 Firebase Remote Config에서 받아오는 걸로 수정

### DIFF
--- a/Clody_iOS/Clody_iOS.xcodeproj/project.pbxproj
+++ b/Clody_iOS/Clody_iOS.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		0BAAC6532C43D74D00174A9D /* ClodyToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BAAC6522C43D74D00174A9D /* ClodyToast.swift */; };
 		0BAAC6552C43D77B00174A9D /* ClodyToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BAAC6542C43D77B00174A9D /* ClodyToastView.swift */; };
 		0BABF7BE2C722313005A5CA1 /* AppVersionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BABF7BD2C722313005A5CA1 /* AppVersionManager.swift */; };
+		0BB74F722E1A6A9B001C1975 /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = 0BB74F712E1A6A9B001C1975 /* FirebaseRemoteConfig */; };
 		0BB898262C85BBBB0082F87B /* RevokeResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BB898252C85BBBB0082F87B /* RevokeResponseDTO.swift */; };
 		0BBD1CD32DF2E94D0063DD35 /* GetDraftDiariesResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BBD1CD22DF2E9430063DD35 /* GetDraftDiariesResponseDTO.swift */; };
 		0BC373532C3FCC2600C45072 /* ViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BC373522C3FCC2600C45072 /* ViewModelType.swift */; };
@@ -329,6 +330,7 @@
 				0BCD4FA52C363C90006390D2 /* FirebaseMessaging in Frameworks */,
 				0B02A8462D6B3D420011AA48 /* AmplitudeSwift in Frameworks */,
 				0BC373592C4003A900C45072 /* RxGesture in Frameworks */,
+				0BB74F722E1A6A9B001C1975 /* FirebaseRemoteConfig in Frameworks */,
 				0BC373562C3FCF0F00C45072 /* RxKeyboard in Frameworks */,
 				0BFCC5B22C2E86EF00B5E0DB /* Lottie in Frameworks */,
 				0BFCC5B92C2E892300B5E0DB /* RxBlocking in Frameworks */,
@@ -1039,6 +1041,7 @@
 				0BCE8F782C908D8500356F53 /* FirebaseCrashlytics */,
 				0B02A8452D6B3D420011AA48 /* AmplitudeSwift */,
 				95CE94DD2D7266790028D308 /* GoogleMobileAds */,
+				0BB74F712E1A6A9B001C1975 /* FirebaseRemoteConfig */,
 			);
 			productName = Clody_iOS;
 			productReference = 0B20F3D92C2C4DAA00F8D62D /* Clody_iOS.app */;
@@ -1652,6 +1655,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 0B6C07352C3B99960054A0B0 /* XCRemoteSwiftPackageReference "RxDataSources" */;
 			productName = RxDataSources;
+		};
+		0BB74F712E1A6A9B001C1975 /* FirebaseRemoteConfig */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0BCD4FA32C363C90006390D2 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseRemoteConfig;
 		};
 		0BC373552C3FCF0F00C45072 /* RxKeyboard */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Clody_iOS/Clody_iOS/Global/Literals/String.swift
+++ b/Clody_iOS/Clody_iOS/Global/Literals/String.swift
@@ -160,4 +160,20 @@ enum I18N {
         static let time = "알림 시간"
         static let replyReceived = "답장 도착 알림 받기"
     }
+    
+    enum AppVersion {
+        static let forceTitle = "필수 업데이트"
+        static func forceMessage(_ version: String) -> String {
+            return "버전 \(version)으로 업데이트가 필요합니다."
+        }
+
+        static let optionalTitle = "업데이트 필요"
+        static func optionalMessage(_ version: String) -> String {
+            return "새로운 버전 \(version)을 사용할 수 있습니다. 지금 업데이트하시겠습니까?"
+        }
+
+        static let update = "업데이트"
+        static let exit = "앱 종료"
+        static let later = "나중에"
+    }
 }

--- a/Clody_iOS/Clody_iOS/Global/Manager/AppVersionManager.swift
+++ b/Clody_iOS/Clody_iOS/Global/Manager/AppVersionManager.swift
@@ -31,7 +31,11 @@ class AppVersionManager {
                 return
             }
             
-            let latestVersion = self.remoteConfig["latest_version_iOS"].stringValue ?? "1.0.0"
+            guard let latestVersion = self.remoteConfig["latest_version_iOS"].stringValue else {
+                completion(true)
+                return
+            }
+
             let currentVersion = self.currentAppVersion()
             
             switch self.compareVersion(currentVersion, latestVersion) {

--- a/Clody_iOS/Clody_iOS/Global/Manager/AppVersionManager.swift
+++ b/Clody_iOS/Clody_iOS/Global/Manager/AppVersionManager.swift
@@ -13,7 +13,7 @@ class AppVersionManager {
     private enum UpdateType {
         case force, optional, none
     }
-
+    
     static let shared = AppVersionManager()
     
     private let remoteConfig = RemoteConfig.remoteConfig()
@@ -30,10 +30,10 @@ class AppVersionManager {
                 completion(true) // 네트워크 오류가 발생한 경우 계속 진행
                 return
             }
-
+            
             let latestVersion = self.remoteConfig["latest_version_iOS"].stringValue ?? "1.0.0"
             let currentVersion = self.currentAppVersion()
-
+            
             switch self.compareVersion(currentVersion, latestVersion) {
             case .force:
                 DispatchQueue.main.async {
@@ -72,16 +72,16 @@ class AppVersionManager {
               let topViewController = windowScene.windows.first?.rootViewController else { return }
         
         let alert = UIAlertController(
-            title: "필수 업데이트",
-            message: "버전 \(appStoreVersion)으로 업데이트가 필요합니다.",
+            title: I18N.AppVersion.forceTitle,
+            message: I18N.AppVersion.forceMessage(appStoreVersion),
             preferredStyle: .alert
         )
         
-        let updateAction = UIAlertAction(title: "업데이트", style: .default) { _ in
+        let updateAction = UIAlertAction(title: I18N.AppVersion.update, style: .default) { _ in
             self.openAppStore()
         }
         
-        let exitAction = UIAlertAction(title: "앱 종료", style: .destructive) { _ in
+        let exitAction = UIAlertAction(title: I18N.AppVersion.exit, style: .destructive) { _ in
             exit(0)
         }
         
@@ -95,16 +95,16 @@ class AppVersionManager {
         guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
               let topViewController = windowScene.windows.first?.rootViewController else { return }
         
-        let alert = UIAlertController(title: "업데이트 필요",
-                                      message: "새로운 버전 \(appStoreVersion)을 사용할 수 있습니다. 지금 업데이트하시겠습니까?",
+        let alert = UIAlertController(title: I18N.AppVersion.optionalTitle,
+                                      message: I18N.AppVersion.optionalMessage(appStoreVersion),
                                       preferredStyle: .alert)
         
-        let updateAction = UIAlertAction(title: "업데이트", style: .default) { _ in
+        let updateAction = UIAlertAction(title: I18N.AppVersion.update, style: .default) { _ in
             self.openAppStore()
             completion(false) // 업데이트를 선택한 경우 스플래시에서 중지
         }
         
-        let cancelAction = UIAlertAction(title: "나중에", style: .cancel) { _ in
+        let cancelAction = UIAlertAction(title: I18N.AppVersion.later, style: .cancel) { _ in
             completion(true) // 나중에를 선택한 경우
         }
         

--- a/Clody_iOS/Clody_iOS/Global/Manager/AppVersionManager.swift
+++ b/Clody_iOS/Clody_iOS/Global/Manager/AppVersionManager.swift
@@ -20,7 +20,7 @@ class AppVersionManager {
     
     private init() {
         let settings = RemoteConfigSettings()
-        settings.minimumFetchInterval = 0
+        settings.minimumFetchInterval = 300
         remoteConfig.configSettings = settings
     }
     

--- a/Clody_iOS/Clody_iOS/Global/Manager/AppVersionManager.swift
+++ b/Clody_iOS/Clody_iOS/Global/Manager/AppVersionManager.swift
@@ -26,16 +26,12 @@ class AppVersionManager {
     
     func checkForUpdateAndProceed(completion: @escaping (Bool) -> Void) {
         remoteConfig.fetchAndActivate { status, error in
-            guard error == nil else {
-                completion(true) // 네트워크 오류가 발생한 경우 계속 진행
-                return
-            }
-            
-            guard let latestVersion = self.remoteConfig["latest_version_iOS"].stringValue else {
+            guard error == nil, let latestVersion = self.remoteConfig["latest_version_iOS"].stringValue else {
                 completion(true)
                 return
             }
-
+            
+            
             let currentVersion = self.currentAppVersion()
             
             switch self.compareVersion(currentVersion, latestVersion) {

--- a/Clody_iOS/Clody_iOS/Global/Manager/AppVersionManager.swift
+++ b/Clody_iOS/Clody_iOS/Global/Manager/AppVersionManager.swift
@@ -6,49 +6,47 @@
 //
 
 import UIKit
+import FirebaseRemoteConfig
 
 class AppVersionManager {
     
     private enum UpdateType {
         case force, optional, none
     }
-    
+
     static let shared = AppVersionManager()
     
+    private let remoteConfig = RemoteConfig.remoteConfig()
+    
+    private init() {
+        let settings = RemoteConfigSettings()
+        settings.minimumFetchInterval = 0
+        remoteConfig.configSettings = settings
+    }
+    
     func checkForUpdateAndProceed(completion: @escaping (Bool) -> Void) {
-        if let url = URL(string: "https://itunes.apple.com/lookup?bundleId=\(Bundle.main.bundleIdentifier!)") {
-            let task = URLSession.shared.dataTask(with: url) { data, response, error in
-                guard let data = data, error == nil else {
-                    completion(true) // 네트워크 오류가 발생한 경우 계속 진행
-                    return
-                }
-                
-                if let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
-                   let results = json["results"] as? [[String: Any]],
-                   let appStoreVersion = results.first?["version"] as? String {
-                    
-                    let currentVersion = self.currentAppVersion()
-                    
-                    switch self.compareVersion(currentVersion, appStoreVersion) {
-                    case .force:
-                        DispatchQueue.main.async {
-                            self.showForceUpdateAlert(appStoreVersion: appStoreVersion)
-                            completion(false)
-                        }
-                    case .optional:
-                        DispatchQueue.main.async {
-                            self.showOptionalUpdateAlert(appStoreVersion: appStoreVersion, completion: completion)
-                        }
-                    case .none:
-                        completion(true)
-                    }
-                } else {
-                    completion(true)
-                }
+        remoteConfig.fetchAndActivate { status, error in
+            guard error == nil else {
+                completion(true) // 네트워크 오류가 발생한 경우 계속 진행
+                return
             }
-            task.resume()
-        } else {
-            completion(true) // URL 오류가 발생한 경우 계속 진행
+
+            let latestVersion = self.remoteConfig["latest_version_iOS"].stringValue ?? "1.0.0"
+            let currentVersion = self.currentAppVersion()
+
+            switch self.compareVersion(currentVersion, latestVersion) {
+            case .force:
+                DispatchQueue.main.async {
+                    self.showForceUpdateAlert(appStoreVersion: latestVersion)
+                    completion(false)
+                }
+            case .optional:
+                DispatchQueue.main.async {
+                    self.showOptionalUpdateAlert(appStoreVersion: latestVersion, completion: completion)
+                }
+            case .none:
+                completion(true)
+            }
         }
     }
     


### PR DESCRIPTION
## 🍀 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
### 작업한 부분
- 기존 앱스토어 API에 의존하여 버전을 받아오는 것을 Firebase Remote Config를 사용하여 버전을 받아오는 안드의 방식을 참고하여
바꿨습니다.
- Firebase의 Remote Config 패키지가 신규로 설치되었습니다.
- AppVersionManager의 String 추출

### 작업한 코드
```swift
    private init() {
        let settings = RemoteConfigSettings()
        settings.minimumFetchInterval = 0
        remoteConfig.configSettings = settings
    }
    
    func checkForUpdateAndProceed(completion: @escaping (Bool) -> Void) {
        remoteConfig.fetchAndActivate { status, error in
            guard error == nil else {
                completion(true) // 네트워크 오류가 발생한 경우 계속 진행
                return
            }
            
            let latestVersion = self.remoteConfig["latest_version_iOS"].stringValue ?? "1.0.0"
            let currentVersion = self.currentAppVersion()
```
- 자체적으로 캐싱을 하고 있어서 RemoteConfig의 minimumFetchInterval을 0으로 하면서, 초기화하면서 새로운 버전을 받아올 수 있도록 하였습니다.
- 기존 앱스토어에서 받아오던 부분을 self.remoteConfig["latest_version_iOS"] 를 통해 파이어베이스에서 조회합니다.

## 🚀 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- 앞으로 업데이트 할때 무조건 파이어베이스 콘솔의 latest_version_iOS의 버전을 바꿔줘야합니다. (수동으로)

## ✚ 코드 리뷰 반영 사항
<!-- 반영한 코드 리뷰 내용이 있다면 적어주세요! -->

## ✅ CheckList
- [ ] 오류 없이 빌드되는지 확인
- [ ] 로그용 print문 제거
- [ ] 불필요한 주석 제거
- [ ] 코드 컨벤션 확인

### 🔗 Issue 
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #128 
