### PR TITLE
Feat [#157] 점검창 현지화

### DIFF
--- a/Clody_iOS/Clody_iOS.xcodeproj/project.pbxproj
+++ b/Clody_iOS/Clody_iOS.xcodeproj/project.pbxproj
@@ -1501,7 +1501,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.2;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Clody.Clody;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1537,7 +1537,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6.2;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Clody.Clody;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Clody_iOS/Clody_iOS/Global/Extensions/String+.swift
+++ b/Clody_iOS/Clody_iOS/Global/Extensions/String+.swift
@@ -203,6 +203,14 @@ extension String {
             comment: "일시적인 오류가 발생했어요. 잠시 후 다시 시도해주세요."
         )
     }
+    
+    enum Downtime {
+        static let description = String(
+            localized: "downtime.description",
+            comment: "보다 안정적인 클로디 서비스를 위해\n시스템 점검 중이에요. 곧 다시 만나요!"
+        )
+        static let confirm = String(localized: "downtime.confirm", comment: "확인")
+    }
 }
 
 

--- a/Clody_iOS/Clody_iOS/Global/Literals/LocalizationConstant.swift
+++ b/Clody_iOS/Clody_iOS/Global/Literals/LocalizationConstant.swift
@@ -89,13 +89,13 @@ enum LocalizationConstant {
         static func headerDate(from date: Date) -> String {
             let formatter = DateFormatter()
             formatter.locale = Locale(identifier: "\(languageCode)_\(regionCode)")
-
+            
             if isKorean {
                 formatter.dateFormat = "M월 d일 EEEE"
             } else {
                 formatter.dateFormat = "EEEE, MMMM d"
             }
-
+            
             return formatter.string(from: date)
         }
     }
@@ -115,6 +115,37 @@ enum LocalizationConstant {
         
         static var textLeading: CGFloat {
             return ScreenUtils.getWidth(isKorean ? 40 : 43)
+        }
+    }
+    
+    enum Downtime {
+        static func formatDowntimePeriod(startTime: String, endTime: String) -> String {
+            let kstFormatter = DateFormatter()
+            kstFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+            kstFormatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+            
+            guard let startDate = kstFormatter.date(from: startTime),
+                  let endDate = kstFormatter.date(from: endTime) else {
+                return ""
+            }
+            
+            let localFormatter = DateFormatter()
+            localFormatter.timeZone = .current
+            localFormatter.locale = Locale(identifier: languageCode)
+            
+            if isKorean {
+                localFormatter.dateFormat = "M/d(E) h:mm"
+                let start = localFormatter.string(from: startDate)
+                localFormatter.dateFormat = "M/d(E) h:mm"
+                let end = localFormatter.string(from: endDate)
+                return "\(start) ~ \(end)"
+            } else {
+                localFormatter.dateFormat = "MMMM d (EEE), h:mm"
+                let start = localFormatter.string(from: startDate)
+                localFormatter.dateFormat = "MMMM d (EEE) h:mm"
+                let end = localFormatter.string(from: endDate)
+                return "\(start) ~ \(end)"
+            }
         }
     }
     

--- a/Clody_iOS/Clody_iOS/Global/Literals/LocalizationConstant.swift
+++ b/Clody_iOS/Clody_iOS/Global/Literals/LocalizationConstant.swift
@@ -138,13 +138,13 @@ enum LocalizationConstant {
                 let start = localFormatter.string(from: startDate)
                 localFormatter.dateFormat = "M/d(E) h:mm"
                 let end = localFormatter.string(from: endDate)
-                return "\(start) ~ \(end)"
+                return "점검 시간: \(start) ~ \(end)"
             } else {
                 localFormatter.dateFormat = "MMMM d (EEE), h:mm"
                 let start = localFormatter.string(from: startDate)
                 localFormatter.dateFormat = "MMMM d (EEE) h:mm"
                 let end = localFormatter.string(from: endDate)
-                return "\(start) ~ \(end)"
+                return "[Maintenance]\n\(start) ~ \(end)"
             }
         }
     }

--- a/Clody_iOS/Clody_iOS/Global/Manager/AppVersionManager.swift
+++ b/Clody_iOS/Clody_iOS/Global/Manager/AppVersionManager.swift
@@ -73,10 +73,20 @@ class AppVersionManager {
                 return
             }
 
-            if let message = self.remoteConfig["downtime_message_iOS"].stringValue,
-               !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                presentMaintenanceScreen(message: message)
-                completion(false)
+            let isDowntime = self.remoteConfig["is_downtime_iOS"].boolValue
+            if isDowntime {
+                let startTimeString = self.remoteConfig["inspection_start_iOS"].stringValue ?? ""
+                let endTimeString = self.remoteConfig["inspection_end_iOS"].stringValue ?? ""
+
+                let formattedTimeString = LocalizationConstant.Downtime.formatDowntimePeriod(
+                    startTime: startTimeString,
+                    endTime: endTimeString
+                )
+                
+                DispatchQueue.main.async {
+                    self.presentMaintenanceScreen(message: formattedTimeString)
+                    completion(false)
+                }
             } else {
                 completion(true)
             }

--- a/Clody_iOS/Clody_iOS/Localizable.xcstrings
+++ b/Clody_iOS/Clody_iOS/Localizable.xcstrings
@@ -1089,6 +1089,40 @@
         }
       }
     },
+    "downtime.confirm" : {
+      "comment" : "확인",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "확인"
+          }
+        }
+      }
+    },
+    "downtime.description" : {
+      "comment" : "보다 안정적인 클로디 서비스를 위해\n시스템 점검 중이에요. 곧 다시 만나요!",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We’re conducting system maintenance \nto improve your experience on Clody. \nSee you again soon!"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "보다 안정적인 클로디 서비스를 위해 \n시스템 점검 중이에요. 곧 다시 만나요!"
+          }
+        }
+      }
+    },
     "error.network" : {
       "comment" : "서비스 접속이 원활하지 않아요. 네트워크 연결을 확인해주세요.",
       "localizations" : {

--- a/Clody_iOS/Clody_iOS/Presentation/Maintenance/Views/MaintenanceView.swift
+++ b/Clody_iOS/Clody_iOS/Presentation/Maintenance/Views/MaintenanceView.swift
@@ -40,20 +40,22 @@ final class MaintenanceView: BaseView {
         
         titleLabel.do {
             $0.textColor = .grey03
-            $0.textAlignment = .center
             $0.numberOfLines = 0
             $0.attributedText = UIFont.pretendardString(
-                text: "보다 안정적인 클로디 서비스를 위해\n시스템 점검 중이에요. 곧 다시 만나요!",
+                text: .Downtime.description,
                 style: .body3_medium,
-                applyLineHeight: true
+                applyLineHeight: true,
+                align: .center
             )
         }
         
         timeLabel.do {
             $0.textColor = .grey04
+            $0.numberOfLines = 0
             $0.attributedText = UIFont.pretendardString(
                 text: "점검 중",
-                style: .body3_medium
+                style: .body3_medium,
+                align: .center
             )
         }
         
@@ -61,7 +63,7 @@ final class MaintenanceView: BaseView {
             $0.setTitleColor(.grey02, for: .normal)
             $0.backgroundColor = .mainYellow
             $0.makeCornerRound(radius: 8)
-            let attributedTitle = UIFont.pretendardString(text: .Common.ok, style: .body3_semibold)
+            let attributedTitle = UIFont.pretendardString(text: .Downtime.confirm, style: .body3_semibold)
             $0.setAttributedTitle(attributedTitle, for: .normal)
         }
     }
@@ -111,8 +113,7 @@ final class MaintenanceView: BaseView {
     }
     
     func configureContent(time: String) {
-        let messaage = "점검 시간: " + time
-        timeLabel.attributedText = UIFont.pretendardString(text: messaage, style: .body3_regular)
+        timeLabel.attributedText = UIFont.pretendardString(text: time, style: .body3_regular, align: .center)
     }
 }
 


### PR DESCRIPTION
## 🍀 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 점검창을 현지화하였습니다.
- 언어와 타임존을 고려하여 시간 계산을 하여 뿌려주는 형식입니다.
- firebase remote config에서 KST 기준의 시간과 다운타임 여부 bool 값을 통해 판단합니다.
- 기존 firebase remote config 방식은 당분간 유지하지만 향후 폐기합니다.

## 🚀 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- 긴급도 상!

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 영어 | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/19833a58-a74e-44b8-998b-ead5fda7f25d" /> |
| 한국어 | <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/c2f5b837-ebda-4fe0-8fd0-adb3e2757659" /> |

## ✚ 코드 리뷰 반영 사항
<!-- 반영한 코드 리뷰 내용이 있다면 적어주세요! -->

## ✅ CheckList
- [ ] 오류 없이 빌드되는지 확인
- [ ] 로그용 print문 제거
- [ ] 불필요한 주석 제거
- [ ] 코드 컨벤션 확인

### 🔗 Issue 
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #157
